### PR TITLE
feat: add visual studio script to automatically run all servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ THUMBS_DB
 .expo/
 
 # VSCode
-.vscode/
 jsconfig.json
 
 # Xcode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
-  }
+  },
+  "cmake.configureOnOpen": false
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,37 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Mobile Expo",
+      "type": "shell",
+      "command": "cd ./apps/mobile && npm start",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new",
+        
+      }
+    },
+    {
+      "label": "EG server",
+      "type": "shell",
+      "command": "cd ./example/server && npm run dev",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new",
+      }
+    },
+    {
+      "label": "EG dashboard",
+      "type": "shell",
+      "command": "cd ./example/dashboard && npm run dev",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new",
+      }
+    },
+    {
+      "label": "Start all servers",
+      "dependsOn": ["Mobile Expo", "EG server", "EG dashboard"]
+    }
+  ]
+}


### PR DESCRIPTION
Open command palette in VSCode and choose: "Preferences: Open keybindings shortcuts (JSON)" and paste the following:
```json
[{
  "key": "cmd+shift+r",
  "command": "workbench.action.tasks.runTask",
  "args": "Start all servers"
}]
```

Then, press "CMD + SHIFT + R" and see this run automatically.

Otherwise, w/o shortcut:

CMD SHIFT P to open command palette, "Tasks: Run Task" and choose "Start all servers"

Here's what it looks like:
<img width="1057" alt="Screenshot 2024-04-18 at 22 43 15" src="https://github.com/final-ui/final/assets/2464966/edb6401a-c66f-466c-9b16-83b145171f2e">
