### PR TITLE
fix: default type w/o zod branded

### DIFF
--- a/packages/playground/src/connection-form.tsx
+++ b/packages/playground/src/connection-form.tsx
@@ -9,13 +9,19 @@ const connectionFormSchema = z.object({
   path: z.string().describe('Path/Location (optional) // Root Location'),
 })
 
+type ConnectionForm = z.infer<typeof connectionFormSchema>
+
+type DefaultValues = {
+  [P in keyof ConnectionForm]: ConnectionForm[P] extends string ? string : ConnectionForm[P]
+}
+
 export function ConnectionForm({
   onSubmit,
   defaultValues,
   submitButton,
 }: {
-  onSubmit: (values: z.infer<typeof connectionFormSchema>) => void
-  defaultValues: z.infer<typeof connectionFormSchema>
+  onSubmit: (values: ConnectionForm) => void
+  defaultValues: DefaultValues
   submitButton: (input: { submit: () => void }) => React.ReactNode
 }) {
   return (


### PR DESCRIPTION
We use branded types to render different inputs depending on what as `schema`. For default values, however, we only accept plain values. We need to exclude `z.BRAND` from the type to avoid type error when passing default values in other parts of the codebase. 

This utility type overwrites any union that includes "string" to just string. It's not future proof, but works for this particular use case.