### PR TITLE
feat: form support 

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -17,7 +17,7 @@ config.resolver.nodeModulesPaths = [
   path.resolve(workspaceRoot, 'node_modules'),
 ]
 
-config.resolver.blockList = exclusionList([/apps\/server\/.*/])
+config.resolver.blockList = exclusionList([/example\/.*/])
 
 config.transformer = { ...config.transformer, unstable_allowRequireContext: true }
 config.transformer.minifierPath = require.resolve('metro-minify-terser')

--- a/example/server/state-schema.ts
+++ b/example/server/state-schema.ts
@@ -118,7 +118,6 @@ export type OffMedia = z.infer<typeof offMediaSchema>
 
 export type Layer = {
   key: string
-  name?: string
   media: Media
   blendMode: 'add' | 'mix' | 'mask'
   blendAmount: number
@@ -133,6 +132,7 @@ const layerSchema: z.ZodType<Layer> = z.object({
 
 export type LayersMedia = {
   type: 'layers'
+  name?: string
   layers: Layer[]
 }
 const layersMediaSchema: z.ZodType<LayersMedia> = z.object({

--- a/example/server/state-schema.ts
+++ b/example/server/state-schema.ts
@@ -118,6 +118,7 @@ export type OffMedia = z.infer<typeof offMediaSchema>
 
 export type Layer = {
   key: string
+  name?: string
   media: Media
   blendMode: 'add' | 'mix' | 'mask'
   blendAmount: number

--- a/example/server/ui.ts
+++ b/example/server/ui.ts
@@ -177,6 +177,41 @@ function getVideoControls(mediaPath: string, state: VideoMedia, context: UIConte
     },
     {
       $: 'component',
+      component: 'RiseForm',
+      props: {
+        onSubmit: {
+          $: 'event',
+        },
+      },
+      children: [
+        {
+          $: 'component',
+          component: 'RiseTextField',
+          props: {
+            name: 'title',
+            label: {
+              $: 'component',
+              component: 'Label',
+              children: 'Layer title',
+              props: {
+                htmlFor: 'title',
+              },
+            },
+            value: state.id,
+            placeholder: 'Enter title...',
+            autoCapitalize: 'none',
+            autoCorrect: false,
+          },
+        },
+        {
+          $: 'component',
+          component: 'RiseSubmitButton',
+          children: 'Submit',
+        },
+      ],
+    },
+    {
+      $: 'component',
       key: 'restart',
       component: 'Button',
       children: 'Restart Video',

--- a/example/server/ui.ts
+++ b/example/server/ui.ts
@@ -799,11 +799,11 @@ function getSequenceControls(
   return []
 }
 
-function getLayersControls(
+function getLayersList(
   mediaLinkPath: string,
   state: LayersMedia,
   context: UIContext,
-  footer: DataState[] = []
+  { header = [], footer = [] }: { header?: DataState[]; footer?: DataState[] } = {}
 ): DataState {
   return {
     $: 'component',
@@ -813,11 +813,17 @@ function getLayersControls(
         $: 'event',
         action: ['updateMedia', mediaLinkPath, 'layerOrder'],
       },
+      header: {
+        $: 'component',
+        component: 'YStack',
+        children: header,
+      },
       footer: {
         $: 'component',
         key: 'addLayer',
         component: 'YStack',
         children: [
+          ...header,
           {
             key: 'addLayer',
             $: 'component',
@@ -965,11 +971,11 @@ export function getMediaUI(
   if (mediaState.type === 'sequence') {
     return scroll([...header, ...getSequenceControls(mediaPath, mediaState, context), ...footer])
   }
-
-  // tbd: locate where this happens and whether we need header there too
-  if (mediaState.type === 'layers') return getLayersControls(mediaPath, mediaState, context, footer)
-
+  if (mediaState.type === 'layers') {
+    return getLayersList(mediaPath, mediaState, context, { header, footer })
+  }
   return scroll([
+    ...header,
     {
       $: 'component',
       component: 'Text',

--- a/packages/kit/src/Form.tsx
+++ b/packages/kit/src/Form.tsx
@@ -1,0 +1,90 @@
+import { ComponentProps, createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import React from 'react'
+import { Button, Fieldset, Form, Input } from 'tamagui'
+
+type FormContext = {
+  values: {
+    [key: string]: any
+  }
+  isSubmitting: boolean
+  setValue: (key: string, value: any) => void
+}
+
+const FormContext = createContext<FormContext>({
+  get values(): never {
+    throw new Error('Wrap your form with a <RiseForm /> component')
+  },
+  isSubmitting: false,
+  setValue: () => {
+    throw new Error('Wrap your form with a <RiseForm /> component')
+  },
+})
+
+export function RiseForm({ children, onSubmit, ...props }: ComponentProps<typeof Form>) {
+  const [values, setValues] = useState({})
+  const [isSubmitting, setSubmitting] = useState(false)
+
+  const submit = async () => {
+    setSubmitting(true)
+    // @ts-ignore
+    // tbd: in the future, parse response from the server and perform update locally
+    await onSubmit?.(values)
+    setSubmitting(false)
+  }
+
+  return (
+    <FormContext.Provider
+      value={{
+        values,
+        isSubmitting,
+        setValue: (key, value) => setValues((state) => ({ ...state, [key]: value })),
+      }}
+    >
+      <Form {...props} onSubmit={submit}>
+        {children}
+      </Form>
+    </FormContext.Provider>
+  )
+}
+
+export const RiseTextField = ({
+  label,
+  name,
+  value,
+  ...props
+}: ComponentProps<typeof Input> & {
+  name: string
+  label: ReactNode
+}) => {
+  const formContext = useContext(FormContext)
+
+  useEffect(() => {
+    formContext.setValue(name, value)
+  }, [value])
+
+  return (
+    <Fieldset>
+      {label}
+      <Input
+        disabled={formContext.isSubmitting}
+        value={formContext.values[name]}
+        onChangeText={(text) => formContext.setValue(name, text)}
+        id={name}
+        {...props}
+      />
+    </Fieldset>
+  )
+}
+
+export const RiseSubmitButton = (props: ComponentProps<typeof Button>) => {
+  return (
+    <Form.Trigger asChild>
+      <Button {...props} />
+    </Form.Trigger>
+  )
+}
+
+// tbd: add validation with Zod
+RiseForm.validate = (props: any) => props
+RiseSubmitButton.validate = (props: any) => props
+RiseTextField.validate = (props: any) => props

--- a/packages/kit/src/Form.tsx
+++ b/packages/kit/src/Form.tsx
@@ -28,7 +28,7 @@ export function RiseForm({ children, onSubmit, ...props }: ComponentProps<typeof
     setSubmitting(true)
     // @ts-ignore
     // tbd: in the future, parse response from the server and perform update locally
-    await onSubmit?.(values)
+    onSubmit?.(values)
     setSubmitting(false)
   }
 

--- a/packages/kit/src/SortableList.tsx
+++ b/packages/kit/src/SortableList.tsx
@@ -17,6 +17,7 @@ const SortableListItemSchema = z.object({
 
 const SortableListProps = z.object({
   footer: z.any(),
+  header: z.any(),
   items: z.array(SortableListItemSchema),
   // tbd: support this event again
   onReorder: EventDataStateSchema.optional(),
@@ -29,6 +30,7 @@ export function SortableList(props: TemplateComponentProps<z.infer<typeof Sortab
         containerStyle={{ flex: 1 }}
         data={props.items}
         keyExtractor={keyExtractor}
+        ListHeaderComponent={props.header}
         ListFooterComponent={props.footer}
         renderItem={(row) => {
           const { item, drag, isActive } = row

--- a/packages/kit/src/index.tsx
+++ b/packages/kit/src/index.tsx
@@ -1,3 +1,4 @@
+import { RiseForm, RiseSubmitButton, RiseTextField } from './Form'
 import { Icon } from './Icon'
 import { QRCode } from './QRCode'
 import { SelectField } from './SelectField'
@@ -33,5 +34,17 @@ export const RiseComponents = {
   RiseSwitchField: {
     component: SwitchField,
     validator: SwitchField.validate,
+  },
+  RiseForm: {
+    component: RiseForm,
+    validator: RiseForm.validate,
+  },
+  RiseTextField: {
+    component: RiseTextField,
+    validator: RiseTextField.validate,
+  },
+  RiseSubmitButton: {
+    component: RiseSubmitButton,
+    validator: RiseSubmitButton.validate,
   },
 }

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "module": "preserve",
+    "moduleResolution": "bundler"
   },
   "references": [{
     "path": "../react"

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -99,7 +99,7 @@ export function BaseTemplate({
 
     if (typeof componentDefinition.validator === 'function') {
       try {
-        componentProps = componentDefinition.validator(stateNode.props)
+        componentProps = componentDefinition.validator(componentProps)
       } catch (e) {
         throw new RenderError(
           `Invalid props for component: ${stateNode.component}, props: ${JSON.stringify(stateNode.props)}. Error: ${JSON.stringify(e)}`

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -12,7 +12,7 @@ export type ComponentDefinition<T extends Record<string, JSONValue>> = {
 /* Component props */
 export type TemplateComponentProps<T> = {
   [P in keyof T]: T[P] extends EventDataState | EventDataState[] | undefined
-    ? (...args: any[]) => void
+    ? (...args: any[]) => Promise<void>
     : T[P]
 }
 
@@ -147,7 +147,7 @@ export function BaseTemplate({
       isEventDataState(stateNode) ||
       (Array.isArray(stateNode) && stateNode.length > 0 && stateNode.every(isEventDataState))
     ) {
-      return (payload: any) => {
+      return async (payload: any) => {
         const nodes = Array.isArray(stateNode) ? stateNode : [stateNode]
         for (const node of nodes) {
           // React events (e.g. from onPress) contain cyclic structures that can't be serialized
@@ -156,6 +156,8 @@ export function BaseTemplate({
           if (payload?.nativeEvent) {
             payload = '[native code]'
           }
+          // tbd: in the future, this should resolve with whatever server responded as a result of the event
+          // this is going to be more efficient and universal than the current approach
           onEvent?.({
             target: { key: parentNode.key, path, component: parentNode.component },
             name: propKey,

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -12,7 +12,7 @@ export type ComponentDefinition<T extends Record<string, JSONValue>> = {
 /* Component props */
 export type TemplateComponentProps<T> = {
   [P in keyof T]: T[P] extends EventDataState | EventDataState[] | undefined
-    ? (...args: any[]) => Promise<void>
+    ? (...args: any[]) => void
     : T[P]
 }
 

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -147,7 +147,7 @@ export function BaseTemplate({
       isEventDataState(stateNode) ||
       (Array.isArray(stateNode) && stateNode.length > 0 && stateNode.every(isEventDataState))
     ) {
-      return async (payload: any) => {
+      return (payload: any) => {
         const nodes = Array.isArray(stateNode) ? stateNode : [stateNode]
         for (const node of nodes) {
           // React events (e.g. from onPress) contain cyclic structures that can't be serialized


### PR DESCRIPTION
This PR adds support for rendering custom form components by the server. Once completed, I plan to remove `ts-form` and `connection-form` entirely and switch to rendering `<Template />` component with form definition.

Notable change is making event handlers `async` on the client. That way, we can `await` on e.g. `onPress` that results in an update being sent to the server. If server responds with something, that can be handled (e.g. perform local update, display an error). That functionality will be added in the future iteration.