### PR TITLE
feat: move form into a modal

### DIFF
--- a/example/server/ui.ts
+++ b/example/server/ui.ts
@@ -920,37 +920,102 @@ export function getMediaLayerUI(mediaPath: string, layer: Layer, context: UICont
 function getLayerForm(mediaPath: string, layer: Layer): ComponentDataState {
   return {
     $: 'component',
-    component: 'RiseForm',
-    props: {
-      onSubmit: {
-        $: 'event',
-        action: ['updateMedia', mediaPath, 'metadata'],
-      },
-    },
+    component: 'AlertDialog',
     children: [
       {
         $: 'component',
-        component: 'RiseTextField',
+        component: 'AlertDialogTrigger',
         props: {
-          name: 'name',
-          label: {
-            $: 'component',
-            component: 'Label',
-            children: 'Layer title',
-            props: {
-              htmlFor: 'title',
-            },
-          },
-          value: layer.name,
-          placeholder: 'Enter title...',
-          autoCapitalize: 'none',
-          autoCorrect: false,
+          asChild: true,
+        },
+        children: {
+          $: 'component',
+          component: 'Button',
+          children: 'Edit title',
         },
       },
       {
         $: 'component',
-        component: 'RiseSubmitButton',
-        children: 'Submit',
+        component: 'AlertDialogPortal',
+        children: [
+          {
+            $: 'component',
+            component: 'AlertDialogOverlay',
+          },
+          {
+            $: 'component',
+            component: 'AlertDialogContent',
+            children: {
+              $: 'component',
+              component: 'RiseForm',
+              props: {
+                onSubmit: {
+                  $: 'event',
+                  action: ['updateMedia', mediaPath, 'metadata'],
+                },
+              },
+              children: [
+                {
+                  $: 'component',
+                  component: 'RiseTextField',
+                  props: {
+                    name: 'name',
+                    label: {
+                      $: 'component',
+                      component: 'Label',
+                      children: 'Layer title',
+                      props: {
+                        htmlFor: 'title',
+                      },
+                    },
+                    value: layer.name,
+                    placeholder: 'Enter title...',
+                    autoCapitalize: 'none',
+                    autoCorrect: false,
+                    marginBottom: '$2',
+                  },
+                },
+                {
+                  $: 'component',
+                  component: 'XStack',
+                  props: {
+                    justifyContent: 'flex-end',
+                    space: '$2',
+                  },
+                  children: [
+                    {
+                      $: 'component',
+                      component: 'AlertDialogCancel',
+                      props: {
+                        asChild: true,
+                      },
+                      children: {
+                        $: 'component',
+                        component: 'Button',
+                        children: 'Cancel',
+                      },
+                    },
+                    {
+                      $: 'component',
+                      component: 'AlertDialogAction',
+                      props: {
+                        asChild: true,
+                      },
+                      children: {
+                        $: 'component',
+                        component: 'RiseSubmitButton',
+                        props: {
+                          theme: 'active',
+                        },
+                        children: 'Submit',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
       },
     ],
   }

--- a/example/server/ui.ts
+++ b/example/server/ui.ts
@@ -965,7 +965,7 @@ function getLayerForm(mediaPath: string, layer: Layer): ComponentDataState {
                       component: 'Label',
                       children: 'Layer title',
                       props: {
-                        htmlFor: 'title',
+                        htmlFor: 'name',
                       },
                     },
                     value: layer.name,

--- a/packages/tamagui/src/index.tsx
+++ b/packages/tamagui/src/index.tsx
@@ -166,6 +166,12 @@ export const TamaguiComponents: ComponentRegistry = {
   AlertDialogOverlay: {
     component: t.AlertDialog.Overlay,
   },
+  AlertDialogAction: {
+    component: t.AlertDialog.Action,
+  },
+  AlertDialogTrigger: {
+    component: t.AlertDialog.Trigger,
+  },
   AlertDialogCancel: {
     component: t.AlertDialog.Cancel,
   },


### PR DESCRIPTION
This PR is a perfect example of why Tamagui is awesome. The `asChild` makes it so easy to combine different components, e.g. AlertClose with a custom Form button. Simply awesome.

PS. Ignore the `warning`, will be fixed in another PR.

<img src="https://github.com/final-ui/final/assets/2464966/c393c11a-4c02-4e3d-91d6-bda8c036e832" width="300" />