### PR TITLE
feat: clean-up paths

### DIFF
--- a/example/server/ui.ts
+++ b/example/server/ui.ts
@@ -1,4 +1,4 @@
-import { ComponentDataState, ServerDataState } from '@final-ui/react'
+import { asyncHandler, ComponentDataState, ServerDataState } from '@final-ui/react'
 
 import { hslToHex } from './color'
 import { EGVideo } from './eg-video-playback'
@@ -936,10 +936,18 @@ function getLayerForm(mediaPath: string, layer: Layer): ComponentDataState {
     $: 'component',
     component: 'RiseForm',
     props: {
-      onSubmit: {
-        $: 'event',
-        action: ['updateMedia', mediaPath, 'metadata'],
-      },
+      onSubmit: asyncHandler(async (args: any) => {
+        console.log('form submitted', JSON.stringify(args))
+        // Simulate a pending state
+        return new Promise((resolve) => {
+          setTimeout(resolve, 5000)
+        })
+        // form submitted
+        // {"target":{"component":"RiseForm","propKey":"onSubmit",
+        // "path":"liveMedia:layer:e71e8271-9dc9-40c0-987b-1000d04f0df3"},
+        // "dataState":{"$":"event","key":"26f727b2-7c28-4736-a3d7-a1102e859fcb","async":true},
+        // "payload":{"name":"dd"}}
+      }),
     },
     children: [
       {

--- a/example/server/ui.ts
+++ b/example/server/ui.ts
@@ -936,18 +936,23 @@ function getLayerForm(mediaPath: string, layer: Layer): ComponentDataState {
     $: 'component',
     component: 'RiseForm',
     props: {
-      onSubmit: asyncHandler(async (args: any) => {
-        console.log('form submitted', JSON.stringify(args))
-        // Simulate a pending state
-        return new Promise((resolve) => {
-          setTimeout(resolve, 5000)
-        })
-        // form submitted
-        // {"target":{"component":"RiseForm","propKey":"onSubmit",
-        // "path":"liveMedia:layer:e71e8271-9dc9-40c0-987b-1000d04f0df3"},
-        // "dataState":{"$":"event","key":"26f727b2-7c28-4736-a3d7-a1102e859fcb","async":true},
-        // "payload":{"name":"dd"}}
-      }),
+      onSubmit: {
+        $: 'event',
+        action: ['updateMedia', mediaPath, 'metadata'],
+      },
+      // Comment this out to test async event handling
+      // onSubmit: asyncHandler(async (args: any) => {
+      //   console.log('form submitted', JSON.stringify(args))
+      //   // Simulate a pending state
+      //   return new Promise((resolve) => {
+      //     setTimeout(resolve, 5000)
+      //   })
+      //   // form submitted
+      //   // {"target":{"component":"RiseForm","propKey":"onSubmit",
+      //   // "path":"liveMedia:layer:e71e8271-9dc9-40c0-987b-1000d04f0df3"},
+      //   // "dataState":{"$":"event","key":"26f727b2-7c28-4736-a3d7-a1102e859fcb","async":true},
+      //   // "payload":{"name":"dd"}}
+      // }),
     },
     children: [
       {

--- a/packages/kit/src/Form.tsx
+++ b/packages/kit/src/Form.tsx
@@ -26,9 +26,8 @@ export function RiseForm({ children, onSubmit, ...props }: ComponentProps<typeof
 
   const submit = async () => {
     setSubmitting(true)
-    // @ts-ignore
-    // tbd: in the future, parse response from the server and perform update locally
-    onSubmit?.(values)
+    // @ts-ignore replace ComponentProps with our own, so that we allow functions to receive args
+    await onSubmit?.(values)
     setSubmitting(false)
   }
 
@@ -77,9 +76,11 @@ export const RiseTextField = ({
 }
 
 export const RiseSubmitButton = (props: ComponentProps<typeof Button>) => {
+  const formContext = useContext(FormContext)
+
   return (
     <Form.Trigger asChild>
-      <Button {...props} />
+      <Button disabled={formContext.isSubmitting} {...props} />
     </Form.Trigger>
   )
 }

--- a/packages/playground/src/screens/connect.tsx
+++ b/packages/playground/src/screens/connect.tsx
@@ -1,10 +1,11 @@
-import { Connection, useConnections } from '@final-ui/playground/src/provider/storage'
 import bs58 from 'bs58'
 import { Buffer } from 'buffer'
 import { useEffect } from 'react'
 import React from 'react'
 import { useRouter } from 'solito/router'
 import { Button, SizableText, YStack } from 'tamagui'
+
+import { Connection, useConnections } from '../provider/storage'
 
 export function ConnectScreen({ connectInfo }: { connectInfo?: string }) {
   const { replace } = useRouter()

--- a/packages/react/src/__tests__/refs.test.tsx
+++ b/packages/react/src/__tests__/refs.test.tsx
@@ -29,12 +29,12 @@ it('should render a component', () => {
   )
 
   expect(component.asFragment()).toMatchInlineSnapshot(`
-<DocumentFragment>
-  <div
-    height="50"
-  />
-</DocumentFragment>
-`)
+    <DocumentFragment>
+      <div
+        height="50"
+      />
+    </DocumentFragment>
+  `)
 })
 
 it('should render component at a path', () => {

--- a/packages/react/src/__tests__/refs.test.tsx
+++ b/packages/react/src/__tests__/refs.test.tsx
@@ -28,12 +28,13 @@ it('should render a component', () => {
     />
   )
 
-  expect(component.getByTestId('root')).toMatchInlineSnapshot(`
-    <div
-      data-testid="root"
-      height="50"
-    />
-  `)
+  expect(component.asFragment()).toMatchInlineSnapshot(`
+<DocumentFragment>
+  <div
+    height="50"
+  />
+</DocumentFragment>
+`)
 })
 
 it('should render component at a path', () => {
@@ -65,12 +66,12 @@ it('should render component at a path', () => {
   )
 
   expect(getStore).toHaveBeenCalledWith('mainStore')
-  expect(component.getByTestId('root')).toMatchInlineSnapshot(`
-    <div
-      data-testid="root"
-    >
-      Hello World!
-    </div>
+  expect(component.asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      <div>
+        Hello World!
+      </div>
+    </DocumentFragment>
   `)
 })
 
@@ -84,6 +85,7 @@ it('should resolve a ref', () => {
         children: [
           {
             $: 'component',
+            key: 'ViewComponent',
             component: 'View',
             children: 'Hello World!',
           },
@@ -109,21 +111,17 @@ it('should resolve a ref', () => {
   )
 
   expect(getStore).toHaveBeenLastCalledWith('mainStore')
-  expect(component.getByTestId('root')).toMatchInlineSnapshot(`
-    <div
-      data-testid="root"
-    >
-      <div
-        data-testid="root.children[0]"
-      >
-        Hello World!
+  expect(component.asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      <div>
+        <div>
+          Hello World!
+        </div>
+        <div>
+          Hello World!
+        </div>
       </div>
-      <div
-        data-testid="root.children[1]"
-      >
-        Hello World!
-      </div>
-    </div>
+    </DocumentFragment>
   `)
 })
 
@@ -212,9 +210,7 @@ it('should manage subscription to stores referenced by refs', () => {
 
   expect(element.asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
-      <div
-        data-testid="root"
-      >
+      <div>
         John Doe
       </div>
     </DocumentFragment>

--- a/packages/react/src/__tests__/template.test.tsx
+++ b/packages/react/src/__tests__/template.test.tsx
@@ -311,3 +311,29 @@ it('should accept event handler as a prop', () => {
 it.skip('should validate props with a validator', () => {})
 
 it.skip('should accept event handlers as nested values in props', () => {})
+
+it('should send an event with path', () => {
+  const onEvent = jest.fn()
+  const component = render(
+    <BaseTemplate
+      components={BUILT_IN_COMPONENTS}
+      path="mainState"
+      dataState={{
+        $: 'component',
+        key: 'button',
+        component: 'View',
+        props: {
+          ['data-testid']: 'button',
+          onClick: {
+            $: 'event',
+          },
+        },
+      }}
+      onEvent={onEvent}
+    />
+  )
+  fireEvent.click(component.getByTestId('button'))
+
+  const firedEvent = onEvent.mock.lastCall[0] as TemplateEvent
+  expect(firedEvent.target.path).toBe('mainState')
+})

--- a/packages/react/src/__tests__/template.test.tsx
+++ b/packages/react/src/__tests__/template.test.tsx
@@ -24,11 +24,12 @@ it('should render a component', () => {
     />
   )
 
-  expect(component.getByTestId('root')).toMatchInlineSnapshot(`
-    <div
-      data-testid="root"
-      height="50"
-    />
+  expect(component.asFragment()).toMatchInlineSnapshot(`
+    <DocumentFragment>
+      <div
+        height="50"
+      />
+    </DocumentFragment>
   `)
 })
 
@@ -39,11 +40,13 @@ it('should render an array of components', () => {
       dataState={[
         {
           $: 'component',
+          key: 'HeadingComponent',
           component: 'View',
           children: 'Heading',
         },
         {
           $: 'component',
+          key: 'HelloWorldComponent',
           component: 'View',
           children: 'Hello, world!',
         },
@@ -54,14 +57,10 @@ it('should render an array of components', () => {
 
   expect(component.asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
-      <div
-        data-testid="root[0]"
-      >
+      <div>
         Heading
       </div>
-      <div
-        data-testid="root[1]"
-      >
+      <div>
         Hello, world!
       </div>
     </DocumentFragment>
@@ -82,13 +81,14 @@ it('should use component key when provided', () => {
           children: [
             {
               $: 'component',
+              key: 'HelloComponent',
               component: 'View',
               children: 'Hello',
             },
             {
               $: 'component',
               component: 'View',
-              key: 'customChildKey',
+              key: 'WorldComponent',
               children: 'World!',
             },
           ],
@@ -100,20 +100,12 @@ it('should use component key when provided', () => {
 
   expect(component.asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
-      <div
-        data-testid="root"
-      >
-        <div
-          data-testid="root.children[customKey]"
-        >
-          <div
-            data-testid="root.children[customKey].children[0]"
-          >
+      <div>
+        <div>
+          <div>
             Hello
           </div>
-          <div
-            data-testid="root.children[customKey].children[customChildKey]"
-          >
+          <div>
             World!
           </div>
         </div>
@@ -141,12 +133,8 @@ it('should render a component with single children', () => {
 
   expect(component.asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
-      <div
-        data-testid="root"
-      >
-        <div
-          data-testid="root.children"
-        >
+      <div>
+        <div>
           Hello, world!
         </div>
       </div>
@@ -165,6 +153,7 @@ it('should render a component with children of different types', () => {
           'Hello',
           {
             $: 'component',
+            key: 'MyComponent',
             component: 'View',
             children: 'world!',
           },
@@ -176,13 +165,9 @@ it('should render a component with children of different types', () => {
 
   expect(component.asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
-      <div
-        data-testid="root"
-      >
+      <div>
         Hello
-        <div
-          data-testid="root.children[1]"
-        >
+        <div>
           world!
         </div>
       </div>
@@ -230,16 +215,12 @@ it('should accept component as a prop', () => {
     <DocumentFragment>
       <section>
         <header>
-          <div
-            data-testid="root.props[header]"
-          >
+          <div>
             Header text
           </div>
         </header>
         <footer>
-          <div
-            data-testid="root.props[paragraph]"
-          >
+          <div>
             Footer text
           </div>
         </footer>
@@ -277,9 +258,7 @@ it('should accept object as a prop', () => {
 
   expect(component.asFragment()).toMatchInlineSnapshot(`
     <DocumentFragment>
-      <section
-        data-testid="root"
-      >
+      <section>
         <header>
           Mike
         </header>
@@ -298,6 +277,7 @@ it('should accept event handler as a prop', () => {
         key: 'button',
         component: 'View',
         props: {
+          ['data-testid']: 'button',
           onClick: {
             $: 'event',
             action: 'navigate',
@@ -308,52 +288,24 @@ it('should accept event handler as a prop', () => {
     />
   )
 
-  fireEvent.click(component.getByTestId('root[button]'))
+  fireEvent.click(component.getByTestId('button'))
 
   expect(onEvent).toHaveBeenCalledTimes(1)
 
   const firedEvent = onEvent.mock.lastCall[0] as TemplateEvent
   expect(firedEvent).toMatchObject({
-    action: 'navigate',
-    name: 'onClick',
+    dataState: {
+      $: 'event',
+      action: 'navigate',
+    },
     target: {
       key: 'button',
-      path: 'root[button]',
+      component: 'View',
+      propKey: 'onClick',
+      path: '',
     },
+    payload: '[native code]',
   })
-  expect(firedEvent.payload).toBe('[native code]')
-})
-
-it('should accept multiple event handlers as a prop', () => {
-  const onEvent = jest.fn()
-  const component = render(
-    <BaseTemplate
-      components={BUILT_IN_COMPONENTS}
-      dataState={{
-        $: 'component',
-        key: 'button',
-        component: 'View',
-        props: {
-          onClick: [
-            {
-              $: 'event',
-              action: 'navigate',
-            },
-            {
-              $: 'event',
-              action: 'onButtonPressed',
-            },
-          ],
-        },
-      }}
-      onEvent={onEvent}
-    />
-  )
-
-  fireEvent.click(component.getByTestId('root[button]'))
-
-  expect(onEvent).toHaveBeenCalledTimes(2)
-  expect(onEvent.mock.calls.map((c) => c[0].action)).toMatchObject(['navigate', 'onButtonPressed'])
 })
 
 it.skip('should validate props with a validator', () => {})

--- a/packages/react/src/events.native.ts
+++ b/packages/react/src/events.native.ts
@@ -1,0 +1,4 @@
+// tbd: move events.ts to a separate package so React Native can build
+// without failing on Node dependency
+//
+// Easiest until experimental_packageExports is turned on by default

--- a/packages/react/src/events.ts
+++ b/packages/react/src/events.ts
@@ -19,7 +19,7 @@ export function isServerEventDataState(obj: ServerDataState): obj is ServerHandl
 export function getAllEventHandlers(dataState: ServerDataState) {
   const acc: Record<string, (args: any) => any> = {}
   function traverse(dataState: ServerDataState) {
-    if (!dataState) {
+    if (!dataState || typeof dataState !== 'object') {
       return
     }
     if (Array.isArray(dataState)) {
@@ -28,14 +28,10 @@ export function getAllEventHandlers(dataState: ServerDataState) {
     }
     if (isComponentDataState(dataState)) {
       Object.values(dataState.props || {}).forEach(traverse)
+      traverse(dataState.children)
       return
     }
     if (isServerEventDataState(dataState)) {
-      if (!dataState.handler) {
-        throw new Error(
-          `You must define "handler" function on the EventDataState. ${JSON.stringify(dataState)}`
-        )
-      }
       acc[dataState.key] = dataState.handler
     }
   }

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -24,7 +24,7 @@ export type DataSource = {
 /** Refs */
 type DataValues = Record<string, JSONValue>
 
-function extractRefValue(dataValues: DataValues, ref: ReferencedDataState['ref']) {
+function lookupRefValue(dataValues: DataValues, ref: ReferencedDataState['ref']) {
   if (typeof ref === 'string') {
     return dataValues[ref]
   }
@@ -40,14 +40,20 @@ function extractRefValue(dataValues: DataValues, ref: ReferencedDataState['ref']
     lookupValue = lookupValue[key]
   }
 
-  if (isComponentDataState(lookupValue)) {
+  return lookupValue
+}
+
+function extractRefValue(dataValues: DataValues, ref: ReferencedDataState['ref']) {
+  const value = lookupRefValue(dataValues, ref)
+
+  if (isComponentDataState(value)) {
     return {
-      ...lookupValue,
+      ...value,
       path: ref,
     }
   }
 
-  return lookupValue
+  return value
 }
 
 export function extractRefKey(ref: Path) {

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -43,7 +43,7 @@ function extractRefValue(dataValues: DataValues, ref: ReferencedDataState['ref']
   if (isComponentDataState(lookupValue)) {
     return {
       ...lookupValue,
-      refKey,
+      path: ref,
     }
   }
 

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -19,7 +19,7 @@ export type ComponentDataState = {
   props?: Record<string, JSONValue>
 }
 type ReferencedComponentDataState = ComponentDataState & {
-  refKey: string
+  path: Path
 }
 export type Path = string | [string, ...(string | number)[]]
 export type ReferencedDataState = {
@@ -150,7 +150,7 @@ export function BaseTemplate({
     if (stateNode.$ === 'component') {
       return renderComponent(
         stateNode,
-        isReferencedComponentDataState(stateNode) ? stateNode.refKey : path
+        isReferencedComponentDataState(stateNode) ? stateNode.path : path
       )
     }
     if (stateNode.$ === 'ref') {

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -15,8 +15,8 @@ export type ComponentDataState = {
   $: 'component'
   key?: string
   component: ComponentIdentifier
-  children?: JSONValue
-  props?: Record<string, JSONValue>
+  children?: DataState
+  props?: Record<string, DataState>
 }
 type ReferencedComponentDataState = ComponentDataState & {
   path: Path
@@ -101,7 +101,7 @@ export function BaseTemplate({
 }: {
   path?: Path
   components: ComponentRegistry
-  dataState: JSONValue
+  dataState: DataState
   onEvent?: (event: TemplateEvent) => Promise<any>
 }) {
   function renderComponent(stateNode: ComponentDataState, path: Path) {

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -87,7 +87,7 @@ export function isComponentDataState(obj: JSONValue): obj is ComponentDataState 
 export function isReferencedComponentDataState(
   obj: JSONValue
 ): obj is ReferencedComponentDataState {
-  return isComponentDataState(obj) && 'refKey' in obj
+  return isComponentDataState(obj) && 'path' in obj
 }
 export function isEventDataState(obj: JSONValue): obj is EventDataState {
   return obj !== null && typeof obj === 'object' && '$' in obj && obj.$ === 'event'

--- a/packages/tamagui/src/__tests__/index.test.tsx
+++ b/packages/tamagui/src/__tests__/index.test.tsx
@@ -19,11 +19,13 @@ it('should render a Tamagui component', () => {
           children: [
             {
               $: 'component',
+              key: 'H1Component',
               component: 'H1',
               children: 'Hello',
             },
             {
               $: 'component',
+              key: 'ParagraphComponent',
               component: 'Paragraph',
               children: 'Welcome to Tamagui!',
             },
@@ -35,33 +37,30 @@ it('should render a Tamagui component', () => {
   )
 
   expect(element.asFragment()).toMatchInlineSnapshot(`
-    <DocumentFragment>
-      <span
-        class="t_light is_inversed _dsp_contents"
+<DocumentFragment>
+  <span
+    class="t_light is_inversed _dsp_contents"
+  >
+    <span
+      class=" t_light _dsp_contents is_Theme"
+    >
+      <div
+        class="_dsp-flex _ai-stretch _fd-row _fb-auto _bxs-border-box _pos-relative _mih-0px _miw-0px _fs-0"
       >
-        <span
-          class=" t_light _dsp_contents is_Theme"
+        <h1
+          class="is_H1 font_heading _col-675002279 _tt-1440318557 _ff-299667014 _fow-1366436877 _ls-905095908 _fos-1477259397 _lh-1677663454 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
+          role="heading"
         >
-          <div
-            class="_dsp-flex _ai-stretch _fd-row _fb-auto _bxs-border-box _pos-relative _mih-0px _miw-0px _fs-0"
-            data-testid="root"
-          >
-            <h1
-              class="is_H1 font_heading _col-675002279 _tt-1440318557 _ff-299667014 _fow-1366436877 _ls-905095908 _fos-1477259397 _lh-1677663454 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
-              data-testid="root.children[0]"
-              role="heading"
-            >
-              Hello
-            </h1>
-            <p
-              class="is_Paragraph font_body _col-675002279 _ff-299667014 _fow-233016140 _ls-167744059 _fos-229441220 _lh-222976573 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
-              data-testid="root.children[1]"
-            >
-              Welcome to Tamagui!
-            </p>
-          </div>
-        </span>
-      </span>
-    </DocumentFragment>
-  `)
+          Hello
+        </h1>
+        <p
+          class="is_Paragraph font_body _col-675002279 _ff-299667014 _fow-233016140 _ls-167744059 _fos-229441220 _lh-222976573 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
+        >
+          Welcome to Tamagui!
+        </p>
+      </div>
+    </span>
+  </span>
+</DocumentFragment>
+`)
 })

--- a/packages/tamagui/src/__tests__/index.test.tsx
+++ b/packages/tamagui/src/__tests__/index.test.tsx
@@ -37,30 +37,30 @@ it('should render a Tamagui component', () => {
   )
 
   expect(element.asFragment()).toMatchInlineSnapshot(`
-<DocumentFragment>
-  <span
-    class="t_light is_inversed _dsp_contents"
-  >
-    <span
-      class=" t_light _dsp_contents is_Theme"
-    >
-      <div
-        class="_dsp-flex _ai-stretch _fd-row _fb-auto _bxs-border-box _pos-relative _mih-0px _miw-0px _fs-0"
+    <DocumentFragment>
+      <span
+        class="t_light is_inversed _dsp_contents"
       >
-        <h1
-          class="is_H1 font_heading _col-675002279 _tt-1440318557 _ff-299667014 _fow-1366436877 _ls-905095908 _fos-1477259397 _lh-1677663454 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
-          role="heading"
+        <span
+          class=" t_light _dsp_contents is_Theme"
         >
-          Hello
-        </h1>
-        <p
-          class="is_Paragraph font_body _col-675002279 _ff-299667014 _fow-233016140 _ls-167744059 _fos-229441220 _lh-222976573 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
-        >
-          Welcome to Tamagui!
-        </p>
-      </div>
-    </span>
-  </span>
-</DocumentFragment>
-`)
+          <div
+            class="_dsp-flex _ai-stretch _fd-row _fb-auto _bxs-border-box _pos-relative _mih-0px _miw-0px _fs-0"
+          >
+            <h1
+              class="is_H1 font_heading _col-675002279 _tt-1440318557 _ff-299667014 _fow-1366436877 _ls-905095908 _fos-1477259397 _lh-1677663454 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
+              role="heading"
+            >
+              Hello
+            </h1>
+            <p
+              class="is_Paragraph font_body _col-675002279 _ff-299667014 _fow-233016140 _ls-167744059 _fos-229441220 _lh-222976573 _dsp-inline _bxs-border-box _ww-break-word _whiteSpace-normal _mt-0px _mr-0px _mb-0px _ml-0px _ussel-auto"
+            >
+              Welcome to Tamagui!
+            </p>
+          </div>
+        </span>
+      </span>
+    </DocumentFragment>
+  `)
 })

--- a/packages/ws-server/src/ws-rnt-server.ts
+++ b/packages/ws-server/src/ws-rnt-server.ts
@@ -1,4 +1,10 @@
-import { ActionEvent, getAllEventHandlers, isHandlerEvent, ServerDataState } from '@final-ui/react'
+import {
+  ActionEvent,
+  extractRefKey,
+  getAllEventHandlers,
+  isHandlerEvent,
+  ServerDataState,
+} from '@final-ui/react'
 import type {
   ClientWebsocketMessage,
   EventWebsocketMessage,
@@ -86,7 +92,7 @@ export function createWSServer(port: number) {
     } = message.event
 
     try {
-      const handleEvent = eventHandlers.get(path)?.[dataState.key]
+      const handleEvent = eventHandlers.get(extractRefKey(path))?.[dataState.key]
       if (!handleEvent) {
         console.warn(
           `Missing event handler on the server for event: ${JSON.stringify(message.event)}`

--- a/packages/ws-server/src/ws-rnt-server.ts
+++ b/packages/ws-server/src/ws-rnt-server.ts
@@ -82,11 +82,11 @@ export function createWSServer(port: number) {
 
     const {
       dataState,
-      target: { storeKey },
+      target: { path },
     } = message.event
 
     try {
-      const handleEvent = eventHandlers.get(storeKey)?.[dataState.key]
+      const handleEvent = eventHandlers.get(path)?.[dataState.key]
       if (!handleEvent) {
         console.warn(
           `Missing event handler on the server for event: ${JSON.stringify(message.event)}`


### PR DESCRIPTION
In this PR, I remove the logic responsible for computing and assigning keys on the client. It turned out to be redundant because of the following reasons:
- keys are not required when there's single child
- when there's an array, keys should be assigned explicitly by the user or alternatively, computed inside JSX factory (like React does), instead of assigning "key={index}" as before, as that does not provide much value

Despite that change, no change required on the server. This is because server was made back when keys were required to avoid warnings. So we're moving back to the roots.

This PR turns `path` into what it used to be before - a store path. The path will change for a referenced component and all its children to point to the path that they come from. This will be necessary to locate that exact component and its handlers on the backend side.