### PR TITLE
feat: automatically reject event handler if request takes too long

### DIFF
--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -35,6 +35,7 @@ export type HandlerEventDataState = {
   $: 'event'
   key: string
   async: boolean
+  timeout?: number
 }
 export function isHandlerEvent(
   event: TemplateEvent


### PR DESCRIPTION
Default timeout: 10s (like Next.js lambda free tier timeout). 