### PR TITLE
feat: ability to respond to events with client-side actions

### DIFF
--- a/example/demo/src/inventory/ui.ts
+++ b/example/demo/src/inventory/ui.ts
@@ -39,7 +39,7 @@ export function getHomeScreen(): ServerDataState {
             props: {
               unstyled: true,
               onPress: {
-                $: 'action',
+                $: 'event',
                 action: ['navigate', `inventory:${item.key}:details`],
               },
               pressStyle: {

--- a/example/demo/src/inventory/ui.ts
+++ b/example/demo/src/inventory/ui.ts
@@ -39,7 +39,7 @@ export function getHomeScreen(): ServerDataState {
             props: {
               unstyled: true,
               onPress: {
-                $: 'event',
+                $: 'action',
                 action: ['navigate', `inventory:${item.key}:details`],
               },
               pressStyle: {

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -76,13 +76,22 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
         }
       }
       const res = await dataSource.sendEvent(event)
-      // res is `null` if we sent `actionEvent` to the server
-      // we would have to disable sending action events to the server to make response always defined
-      if (res?.actions) {
+      if (!res) {
+        // res is `null` if we sent `actionEvent` to the server
+        // we would have to disable sending action events to the server to make response always defined
+        return
+      }
+      if (res.actions) {
+        // response has local actions to execute on the client as a follow-up
         for (const action of res.actions) {
           handleActionEvent(action)
         }
       }
+      if (!res.ok) {
+        // if response was not okay, throw the payload as an error
+        throw res.payload
+      }
+      // resolve otherwise
       return res?.payload
     },
     [dataSource, handleActionEvent]

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -50,7 +50,7 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
     }
   }, [path])
 
-  const handleActionEvent = useCallback(
+  const onAction = useCallback(
     (dataState: ActionEventDataState) => {
       const [action, path] = Array.isArray(dataState.action)
         ? dataState.action
@@ -67,39 +67,9 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
     [router]
   )
 
-  const onEvent = useCallback(
-    async (event: TemplateEvent) => {
-      if (isActionEvent(event)) {
-        if (handleActionEvent(event.dataState)) {
-          // do not send handled events to the server
-          return
-        }
-      }
-      const res = await dataSource.sendEvent(event)
-      if (!res) {
-        // res is `null` if we sent `actionEvent` to the server
-        // we would have to disable sending action events to the server to make response always defined
-        return
-      }
-      if (res.actions) {
-        // response has local actions to execute on the client as a follow-up
-        for (const action of res.actions) {
-          handleActionEvent(action)
-        }
-      }
-      if (!res.ok) {
-        // if response was not okay, throw the payload as an error
-        throw res.payload
-      }
-      // resolve otherwise
-      return res?.payload
-    },
-    [dataSource, handleActionEvent]
-  )
-
   return (
     <DataBoundary dataSource={dataSource} path={path!}>
-      <Template components={components} dataSource={dataSource} path={path!} onEvent={onEvent} />
+      <Template components={components} dataSource={dataSource} path={path!} onAction={onAction} />
     </DataBoundary>
   )
 }

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -1,5 +1,5 @@
 import { RiseComponents } from '@final-ui/kit'
-import { Template } from '@final-ui/react'
+import { ActionEventDataState, Template } from '@final-ui/react'
 import { TamaguiComponents } from '@final-ui/tamagui'
 import { Stack } from 'expo-router'
 import React, { useCallback, useEffect } from 'react'
@@ -51,13 +51,13 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
   }, [path])
 
   const onAction = useCallback(
-    (action: string | string[]) => {
-      const [operation, path] = Array.isArray(action) ? action : [action, '']
-      if (operation === 'navigate') {
+    (event: ActionEventDataState<string | string[]>) => {
+      const [action, path] = Array.isArray(event.action) ? event.action : [event.action, '']
+      if (action === 'navigate') {
         router.push(`/connection/${params.id}?path=${path}`)
         return true
       }
-      if (operation === 'navigate-back') {
+      if (action === 'navigate-back') {
         router.back()
         return true
       }

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -2,7 +2,7 @@ import { RiseComponents } from '@final-ui/kit'
 import { isActionEvent, Template, TemplateEvent } from '@final-ui/react'
 import { TamaguiComponents } from '@final-ui/tamagui'
 import { Stack } from 'expo-router'
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback } from 'react'
 import { createParam } from 'solito'
 import { useRouter } from 'solito/router'
 
@@ -44,36 +44,28 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
     return null
   }
 
-  useEffect(() => {
-    return dataSource.onEvent((dataState) => {
-      const [action, path] = Array.isArray(dataState.action)
-        ? dataState.action
-        : [dataState.action, '']
-      if (action === 'navigate') {
-        router.push(`/connection/${params.id}?path=${path}`)
-        return
+  const onEvent = useCallback(
+    async (event: TemplateEvent) => {
+      if (isActionEvent(event)) {
+        const [action, path] = Array.isArray(event.dataState.action)
+          ? event.dataState.action
+          : [event.dataState.action, '']
+        if (action === 'navigate') {
+          router.push(`/connection/${params.id}?path=${path}`)
+          return
+        }
+        if (action === 'navigate-back') {
+          router.back()
+          return
+        }
       }
-      if (action === 'navigate-back') {
-        router.back()
-        return
-      }
-    })
-  }, [])
-
-  useEffect(() => {
-    if (path === undefined) {
-      router.back()
-    }
-  }, [path])
+    },
+    [dataSource]
+  )
 
   return (
     <DataBoundary dataSource={dataSource} path={path!}>
-      <Template
-        components={components}
-        dataSource={dataSource}
-        path={path!}
-        onEvent={dataSource.sendEvent}
-      />
+      <Template components={components} dataSource={dataSource} path={path!} onEvent={onEvent} />
     </DataBoundary>
   )
 }

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -80,13 +80,7 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
         components={components}
         dataSource={dataSource}
         path={path!}
-        onEvent={async (event) => {
-          if (isActionEvent(event)) {
-            handleActionEvent(event.dataState)
-            return
-          }
-          return dataSource.sendEvent(event)
-        }}
+        onEvent={dataSource.sendEvent}
       />
     </DataBoundary>
   )

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -85,7 +85,7 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
       }
       return res?.payload
     },
-    [dataSource]
+    [dataSource, handleActionEvent]
   )
 
   return (

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -45,34 +45,35 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
   }
 
   useEffect(() => {
+    return dataSource.onEvent((dataState) => {
+      const [action, path] = Array.isArray(dataState.action)
+        ? dataState.action
+        : [dataState.action, '']
+      if (action === 'navigate') {
+        router.push(`/connection/${params.id}?path=${path}`)
+        return
+      }
+      if (action === 'navigate-back') {
+        router.back()
+        return
+      }
+    })
+  }, [])
+
+  useEffect(() => {
     if (path === undefined) {
       router.back()
     }
   }, [path])
 
-  const onEvent = useCallback(
-    async (event: TemplateEvent) => {
-      if (isActionEvent(event)) {
-        const [action, path] = Array.isArray(event.dataState.action)
-          ? event.dataState.action
-          : [event.dataState.action, '']
-        if (action === 'navigate') {
-          router.push(`/connection/${params.id}?path=${path}`)
-          return
-        }
-        if (action === 'navigate-back') {
-          router.back()
-          return
-        }
-      }
-      return dataSource.sendEvent(event)
-    },
-    [dataSource]
-  )
-
   return (
     <DataBoundary dataSource={dataSource} path={path!}>
-      <Template components={components} dataSource={dataSource} path={path!} onEvent={onEvent} />
+      <Template
+        components={components}
+        dataSource={dataSource}
+        path={path!}
+        onEvent={dataSource.sendEvent}
+      />
     </DataBoundary>
   )
 }

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -1,5 +1,5 @@
 import { RiseComponents } from '@final-ui/kit'
-import { ActionEventDataState, isActionEvent, Template, TemplateEvent } from '@final-ui/react'
+import { Template } from '@final-ui/react'
 import { TamaguiComponents } from '@final-ui/tamagui'
 import { Stack } from 'expo-router'
 import React, { useCallback, useEffect } from 'react'
@@ -51,15 +51,13 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
   }, [path])
 
   const onAction = useCallback(
-    (dataState: ActionEventDataState) => {
-      const [action, path] = Array.isArray(dataState.action)
-        ? dataState.action
-        : [dataState.action, '']
-      if (action === 'navigate') {
+    (action: string | string[]) => {
+      const [operation, path] = Array.isArray(action) ? action : [action, '']
+      if (operation === 'navigate') {
         router.push(`/connection/${params.id}?path=${path}`)
         return true
       }
-      if (action === 'navigate-back') {
+      if (operation === 'navigate-back') {
         router.back()
         return true
       }

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -83,7 +83,7 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
           handleActionEvent(action)
         }
       }
-      return res
+      return res?.payload
     },
     [dataSource]
   )

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -2,7 +2,7 @@ import { RiseComponents } from '@final-ui/kit'
 import { isActionEvent, Template, TemplateEvent } from '@final-ui/react'
 import { TamaguiComponents } from '@final-ui/tamagui'
 import { Stack } from 'expo-router'
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { createParam } from 'solito'
 import { useRouter } from 'solito/router'
 
@@ -44,6 +44,12 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
     return null
   }
 
+  useEffect(() => {
+    if (path === undefined) {
+      router.back()
+    }
+  }, [path])
+
   const onEvent = useCallback(
     async (event: TemplateEvent) => {
       if (isActionEvent(event)) {
@@ -59,6 +65,7 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
           return
         }
       }
+      return dataSource.sendEvent(event)
     },
     [dataSource]
   )

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -1,5 +1,11 @@
 import { RiseComponents } from '@final-ui/kit'
-import { isActionEvent, Template, TemplateEvent } from '@final-ui/react'
+import {
+  ActionEvent,
+  ActionEventDataState,
+  isActionEvent,
+  Template,
+  TemplateEvent,
+} from '@final-ui/react'
 import { TamaguiComponents } from '@final-ui/tamagui'
 import { Stack } from 'expo-router'
 import React, { useCallback, useEffect } from 'react'
@@ -50,29 +56,38 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
     }
   }, [path])
 
-  const onEvent = useCallback(
-    async (event: TemplateEvent) => {
-      if (isActionEvent(event)) {
-        const [action, path] = Array.isArray(event.dataState.action)
-          ? event.dataState.action
-          : [event.dataState.action, '']
-        if (action === 'navigate') {
-          router.push(`/connection/${params.id}?path=${path}`)
-          return
-        }
-        if (action === 'navigate-back') {
-          router.back()
-          return
-        }
-      }
-      return dataSource.sendEvent(event)
-    },
-    [dataSource]
-  )
+  const handleActionEvent = (dataState: ActionEventDataState) => {
+    const [action, path] = Array.isArray(dataState.action)
+      ? dataState.action
+      : [dataState.action, '']
+    if (action === 'navigate') {
+      router.push(`/connection/${params.id}?path=${path}`)
+      return
+    }
+    if (action === 'navigate-back') {
+      router.back()
+      return
+    }
+  }
+
+  useEffect(() => {
+    dataSource.onEvent((event) => handleActionEvent(event))
+  }, [dataSource])
 
   return (
     <DataBoundary dataSource={dataSource} path={path!}>
-      <Template components={components} dataSource={dataSource} path={path!} onEvent={onEvent} />
+      <Template
+        components={components}
+        dataSource={dataSource}
+        path={path!}
+        onEvent={async (event) => {
+          if (isActionEvent(event)) {
+            handleActionEvent(event.dataState)
+            return
+          }
+          return dataSource.sendEvent(event)
+        }}
+      />
     </DataBoundary>
   )
 }

--- a/packages/playground/src/screens/connection.tsx
+++ b/packages/playground/src/screens/connection.tsx
@@ -80,7 +80,13 @@ function ActiveConnectionScreen({ connection }: { connection: Connection }) {
         components={components}
         dataSource={dataSource}
         path={path!}
-        onEvent={dataSource.sendEvent}
+        onEvent={async (event) => {
+          if (isActionEvent(event)) {
+            handleActionEvent(event.dataState)
+            return
+          }
+          return dataSource.sendEvent(event)
+        }}
       />
     </DataBoundary>
   )

--- a/packages/react/src/__tests__/events.test.ts
+++ b/packages/react/src/__tests__/events.test.ts
@@ -10,6 +10,7 @@ it('should return all event handlers from the object', () => {
       // this is not an event handler and should be ignored
       onPress: {
         $: 'event',
+        action: 'foo',
       },
     },
     children: {

--- a/packages/react/src/__tests__/refs.test.tsx
+++ b/packages/react/src/__tests__/refs.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 
-import { ActionEventDataState, DataSource, res, Template } from '..'
+import { ActionEventDataState, createResponse, DataSource, Template } from '..'
 import { BUILT_IN_COMPONENTS } from './template.test'
 
 it('should render a component', () => {
@@ -138,7 +138,7 @@ it('should resolve a ref', () => {
   `)
 })
 
-it('should send an event with ref as a path when trigerred by referenced component', () => {
+it('should send an action with ref as a path when trigerred by referenced component', () => {
   const dataSource: DataSource = {
     get: (store: string) => {
       if (store === 'secondStore') {
@@ -188,7 +188,7 @@ it('should send an event with ref as a path when trigerred by referenced compone
         },
       }
     },
-    sendEvent: jest.fn().mockResolvedValue(res(null)),
+    sendEvent: jest.fn().mockResolvedValue(createResponse(null)),
   }
 
   const onAction = jest.fn()

--- a/packages/react/src/__tests__/refs.test.tsx
+++ b/packages/react/src/__tests__/refs.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 
-import { DataSource, Template, TemplateEvent } from '..'
+import { ActionEventDataState, DataSource, res, Template } from '..'
 import { BUILT_IN_COMPONENTS } from './template.test'
 
 it('should render a component', () => {
@@ -153,6 +153,7 @@ it('should send an event with ref as a path when trigerred by referenced compone
                 ['data-testid']: 'button-referenced',
                 onClick: {
                   $: 'event',
+                  action: 'go-back-referenced',
                 },
               },
             }
@@ -174,6 +175,7 @@ it('should send an event with ref as a path when trigerred by referenced compone
                   ['data-testid']: 'button-local',
                   onClick: {
                     $: 'event',
+                    action: 'go-back-local',
                   },
                 },
               },
@@ -186,23 +188,23 @@ it('should send an event with ref as a path when trigerred by referenced compone
         },
       }
     },
-    sendEvent: jest.fn(),
+    sendEvent: jest.fn().mockResolvedValue(res(null)),
   }
 
-  const onEvent = jest.fn()
+  const onAction = jest.fn()
   const component = render(
     <Template
       components={BUILT_IN_COMPONENTS}
       path="mainStore"
       dataSource={dataSource}
-      onEvent={onEvent}
+      onAction={onAction}
     />
   )
   fireEvent.click(component.getByTestId('button-local'))
-  expect((onEvent.mock.lastCall[0] as TemplateEvent).target.path).toEqual('mainStore')
+  expect((onAction.mock.lastCall[0] as ActionEventDataState).action).toEqual('go-back-local')
 
   fireEvent.click(component.getByTestId('button-referenced'))
-  expect((onEvent.mock.lastCall[0] as TemplateEvent).target.path).toEqual('secondStore')
+  expect((onAction.mock.lastCall[0] as ActionEventDataState).action).toEqual('go-back-referenced')
 })
 
 it('should subscribe to the root store', () => {

--- a/packages/react/src/__tests__/template.test.tsx
+++ b/packages/react/src/__tests__/template.test.tsx
@@ -20,7 +20,7 @@ it('should render a component', () => {
           height: 50,
         },
       }}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -51,7 +51,7 @@ it('should render an array of components', () => {
           children: 'Hello, world!',
         },
       ]}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -94,7 +94,7 @@ it('should use component key when provided', () => {
           ],
         },
       }}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -127,7 +127,7 @@ it('should render a component with single children', () => {
           children: 'Hello, world!',
         },
       }}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -159,7 +159,7 @@ it('should render a component with children of different types', () => {
           },
         ],
       }}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -207,7 +207,7 @@ it('should accept component as a prop', () => {
           },
         },
       }}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -252,7 +252,7 @@ it('should accept object as a prop', () => {
           },
         },
       }}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -284,7 +284,7 @@ it('should accept event handler as a prop', () => {
           },
         },
       }}
-      onEvent={onEvent}
+      onTemplateEvent={onEvent}
     />
   )
 
@@ -330,7 +330,7 @@ it('should validate props with a validator', () => {
         component: 'View',
         props,
       }}
-      onEvent={jest.fn()}
+      onTemplateEvent={jest.fn()}
     />
   )
 
@@ -351,10 +351,11 @@ it('should send an event with path', () => {
           ['data-testid']: 'button',
           onClick: {
             $: 'event',
+            action: 'go-back',
           },
         },
       }}
-      onEvent={onEvent}
+      onTemplateEvent={onEvent}
     />
   )
   fireEvent.click(component.getByTestId('button'))

--- a/packages/react/src/events.ts
+++ b/packages/react/src/events.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto'
 import { ServerResponse } from './response'
 import {
   DataState,
-  EventDataState,
+  HandlerEventDataState,
   isComponentDataState,
   isEventDataState,
   JSONValue,
@@ -11,8 +11,9 @@ import {
 
 /** Server data state*/
 export type ServerDataState = DataState | ServerEventDataState
-export type ServerEventDataState<T = ServerHandlerFunction> = EventDataState & {
-  handler: T
+export type ServerHandlerFunction = (args: any) => Promise<ServerResponse | JSONValue>
+export type ServerEventDataState = HandlerEventDataState & {
+  handler: ServerHandlerFunction
 }
 export function isServerEventDataState(obj: ServerDataState): obj is ServerEventDataState {
   return isEventDataState(obj) && 'handler' in obj && typeof obj.handler === 'function'
@@ -41,8 +42,7 @@ export function getAllEventHandlers(dataState: ServerDataState) {
   return acc
 }
 
-export type ServerHandlerFunction = (args: any) => Promise<ServerResponse | JSONValue>
-export function handler(func: ServerHandlerFunction): ServerEventDataState<ServerHandlerFunction> {
+export function handler(func: ServerHandlerFunction): ServerEventDataState {
   const key = crypto.randomUUID()
   return {
     $: 'event',

--- a/packages/react/src/events.ts
+++ b/packages/react/src/events.ts
@@ -42,9 +42,7 @@ export function getAllEventHandlers(dataState: ServerDataState) {
 }
 
 export type ServerHandlerFunction = (args: any) => Promise<ServerResponse | JSONValue>
-export function asyncHandler(
-  func: ServerHandlerFunction
-): ServerEventDataState<ServerHandlerFunction> {
+export function handler(func: ServerHandlerFunction): ServerEventDataState<ServerHandlerFunction> {
   const key = crypto.randomUUID()
   return {
     $: 'event',

--- a/packages/react/src/events.ts
+++ b/packages/react/src/events.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 
-import { ServerResponse } from './response'
+import { ServerResponseDataState } from './response'
 import {
   DataState,
   HandlerEventDataState,
@@ -11,7 +11,10 @@ import {
 
 /** Server data state*/
 export type ServerDataState = DataState | ServerEventDataState
-export type ServerHandlerFunction = (args: any) => Promise<ServerResponse | JSONValue>
+type ServerHandlerReturnType = ServerResponseDataState | JSONValue | void
+export type ServerHandlerFunction = (
+  args: any
+) => Promise<ServerHandlerReturnType> | ServerHandlerReturnType
 export type ServerEventDataState = HandlerEventDataState & {
   handler: ServerHandlerFunction
 }

--- a/packages/react/src/events.ts
+++ b/packages/react/src/events.ts
@@ -3,18 +3,18 @@ import crypto from 'node:crypto'
 import { ServerResponse } from './response'
 import {
   DataState,
-  HandlerEventDataState,
+  EventDataState,
   isComponentDataState,
   isEventDataState,
   JSONValue,
 } from './template'
 
 /** Server data state*/
-export type ServerDataState = DataState | ServerHandlerEventDataState
-export type ServerHandlerEventDataState<T = ServerHandlerFunction> = HandlerEventDataState & {
+export type ServerDataState = DataState | ServerEventDataState
+export type ServerEventDataState<T = ServerHandlerFunction> = EventDataState & {
   handler: T
 }
-export function isServerEventDataState(obj: ServerDataState): obj is ServerHandlerEventDataState {
+export function isServerEventDataState(obj: ServerDataState): obj is ServerEventDataState {
   return isEventDataState(obj) && 'handler' in obj && typeof obj.handler === 'function'
 }
 
@@ -44,7 +44,7 @@ export function getAllEventHandlers(dataState: ServerDataState) {
 type SyncServerHandlerFunction = (args: any) => ServerResponse | JSONValue
 export function handler(
   func: SyncServerHandlerFunction
-): ServerHandlerEventDataState<SyncServerHandlerFunction> {
+): ServerEventDataState<SyncServerHandlerFunction> {
   const key = crypto.randomUUID()
   return {
     $: 'event',
@@ -57,7 +57,7 @@ export function handler(
 type AsyncServerHandlerFunction = (args: any) => Promise<ReturnType<SyncServerHandlerFunction>>
 export function asyncHandler(
   func: AsyncServerHandlerFunction
-): ServerHandlerEventDataState<AsyncServerHandlerFunction> {
+): ServerEventDataState<AsyncServerHandlerFunction> {
   const key = crypto.randomUUID()
   return {
     $: 'event',

--- a/packages/react/src/events.ts
+++ b/packages/react/src/events.ts
@@ -41,30 +41,14 @@ export function getAllEventHandlers(dataState: ServerDataState) {
   return acc
 }
 
-type SyncServerHandlerFunction = (args: any) => ServerResponse | JSONValue
-export function handler(
-  func: SyncServerHandlerFunction
-): ServerEventDataState<SyncServerHandlerFunction> {
-  const key = crypto.randomUUID()
-  return {
-    $: 'event',
-    key,
-    async: false,
-    handler: func,
-  }
-}
-
-type AsyncServerHandlerFunction = (args: any) => Promise<ReturnType<SyncServerHandlerFunction>>
+export type ServerHandlerFunction = (args: any) => Promise<ServerResponse | JSONValue>
 export function asyncHandler(
-  func: AsyncServerHandlerFunction
-): ServerEventDataState<AsyncServerHandlerFunction> {
+  func: ServerHandlerFunction
+): ServerEventDataState<ServerHandlerFunction> {
   const key = crypto.randomUUID()
   return {
     $: 'event',
     key,
-    async: true,
     handler: func,
   }
 }
-
-export type ServerHandlerFunction = SyncServerHandlerFunction | AsyncServerHandlerFunction

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,4 +1,5 @@
 export * from './events'
 export * from './refs'
+export * from './response'
 export * from './streams'
 export * from './template'

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -164,13 +164,8 @@ function resolveValueRefs(dataValues: DataValues, value: DataState): DataState {
     if (isCompositeDataState(value) && value.$ === 'ref') {
       return resolveRef(dataValues, value.ref)
     }
-    // @ts-ignore
     return Object.fromEntries(
       Object.entries(value).map(([key, item]) => {
-        // tbd: Typescript complains b/c the return type of this can also be
-        // Record<string, DataState>. However, the end return type is always "DataState".
-        // We likely need an inner function
-        // @ts-ignore
         return [key, resolveValueRefs(dataValues, item)]
       })
     )

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -211,17 +211,14 @@ export function Template({
       onEvent={async (event) => {
         const res = await onEvent(event)
         if (res.actions) {
-          // response has local actions to execute on the client as a follow-up
           for (const action of res.actions) {
             onAction?.(action)
           }
         }
         if (!res.ok) {
-          // if response was not okay, throw the payload as an error
           throw res.payload
         }
-        // resolve otherwise
-        return res?.payload
+        return res.payload
       }}
     />
   )

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react'
 
-import { ServerResponse } from './response'
+import { ServerResponseDataState } from './response'
 import { Stream } from './streams'
 import {
   ActionEvent,
@@ -20,7 +20,7 @@ export type Store<T = DataState> = Stream<T>
 
 export type DataSource = {
   get: (key: string) => Store
-  sendEvent: (event: HandlerEvent) => Promise<ServerResponse>
+  sendEvent: (event: HandlerEvent) => Promise<ServerResponseDataState>
 }
 
 /** Refs */
@@ -193,7 +193,7 @@ export function Template({
   dataSource: DataSource
   components: ComponentRegistry
   onAction: (action: ActionEventDataState) => void
-  onEvent?: (event: HandlerEvent) => Promise<ServerResponse>
+  onEvent?: (event: HandlerEvent) => Promise<ServerResponseDataState>
 }) {
   const [dataValues, setDataValues] = useState<DataValues>({})
   const refStateManager = useRef(

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -210,7 +210,7 @@ export function Template({
       dataState={rootDataState}
       onTemplateEvent={async (event) => {
         if (isActionEvent(event)) {
-          onAction?.(event.dataState)
+          onAction?.(event)
           return
         }
         const res = await onEvent(event)

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react'
 
-import { ServerResponseDataState } from './response'
+import { isResponseDataState, ServerResponseDataState } from './response'
 import { Stream } from './streams'
 import {
   ActionEvent,
@@ -187,7 +187,7 @@ export function Template({
   path?: Path
   dataSource: DataSource
   components: ComponentRegistry
-  onAction: (action: ActionEventDataState) => void
+  onAction?: (action: ActionEventDataState) => void
   onEvent?: (event: HandlerEvent) => Promise<ServerResponseDataState>
 }) {
   const [dataValues, setDataValues] = useState<DataValues>({})
@@ -206,6 +206,11 @@ export function Template({
         return
       }
       const res = await onEvent(event)
+      if (!isResponseDataState(res)) {
+        throw new Error(
+          `Invalid response from "onEvent" handler. Expected ServerResponseDataState. Received: ${JSON.stringify(res)}`
+        )
+      }
       if (res.actions) {
         for (const action of res.actions) {
           onAction?.(action)

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -190,7 +190,7 @@ export function Template({
   dataSource: DataSource
   components: ComponentRegistry
   onAction: ComponentProps<typeof BaseTemplate>['onAction']
-  onEvent?: ComponentProps<typeof BaseTemplate>['onEvent']
+  onEvent?: DataSource['sendEvent']
 }) {
   const [dataValues, setDataValues] = useState<DataValues>({})
   const refStateManager = useRef(

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -1,8 +1,8 @@
 import React, { ComponentProps, Dispatch, SetStateAction, useEffect, useRef, useState } from 'react'
 
+import { ServerResponse } from './response'
 import { Stream } from './streams'
 import {
-  ActionEventDataState,
   BaseTemplate,
   ComponentRegistry,
   DataState,
@@ -15,11 +15,9 @@ import {
 
 export type Store<T = DataState> = Stream<T>
 
-export type DataSourceActionEventHandler = (event: ActionEventDataState) => void
 export type DataSource = {
   get: (key: string) => Store
-  onEvent: (handler: DataSourceActionEventHandler) => void
-  sendEvent: (event: TemplateEvent) => Promise<any>
+  sendEvent: (event: TemplateEvent) => Promise<ServerResponse | null>
 }
 
 /** Refs */

--- a/packages/react/src/refs.tsx
+++ b/packages/react/src/refs.tsx
@@ -192,8 +192,8 @@ export function Template({
   path?: Path
   dataSource: DataSource
   components: ComponentRegistry
-  onAction: (event: ActionEventDataState) => void
-  onEvent?: DataSource['sendEvent']
+  onAction: (action: ActionEventDataState) => void
+  onEvent?: (event: HandlerEvent) => Promise<ServerResponse>
 }) {
   const [dataValues, setDataValues] = useState<DataValues>({})
   const refStateManager = useRef(

--- a/packages/react/src/response.ts
+++ b/packages/react/src/response.ts
@@ -1,6 +1,4 @@
-import { ActionEventDataState } from './template'
-
-export type ServerHandlerResponse = any
+import { ActionEventDataState, JSONValue } from './template'
 
 // tbd
 // what kind of API do we want?
@@ -16,7 +14,7 @@ export type ServerHandlerResponse = any
 // client-side hooks such as "onEvent()" where you can listen to e.g. global onError and display
 // an appropriate error state
 export const res = {
-  json(payload: any) {
+  json(payload: JSONValue) {
     const res = new ServerResponse()
     res.payload = payload
     return res
@@ -27,8 +25,18 @@ export class ServerResponse {
   actions: ActionEventDataState[] = []
   payload: any
 
+  // what are default values in `fetch`?
+  statusCode: number = 200
+  ok: boolean = true
+
   action(action: ActionEventDataState) {
     this.actions.push(action)
+    return this
+  }
+
+  status(code: number) {
+    this.statusCode = code
+    this.ok = code >= 200 && code < 300
     return this
   }
 }

--- a/packages/react/src/response.ts
+++ b/packages/react/src/response.ts
@@ -1,4 +1,4 @@
-import { ActionDataState, JSONValue } from './template'
+import { ActionEventDataState, JSONValue } from './template'
 
 // tbd
 // what kind of API do we want?
@@ -22,7 +22,7 @@ export const res = {
 }
 
 export class ServerResponse {
-  actions: ActionDataState[] = []
+  actions: ActionEventDataState[] = []
   payload: any
 
   // what are default values in `fetch`?
@@ -31,7 +31,7 @@ export class ServerResponse {
 
   action(action: any) {
     this.actions.push({
-      $: 'action',
+      $: 'event',
       action,
     })
     return this

--- a/packages/react/src/response.ts
+++ b/packages/react/src/response.ts
@@ -1,0 +1,34 @@
+import { ActionEventDataState } from './template'
+
+export type ServerHandlerResponse = any
+
+// tbd
+// what kind of API do we want?
+// e.g. `res.json().action([])`
+// or
+// `return makeActionResponse()
+// the implementation of this file will have to change based on the decision
+// benefit of `json()` is we can support array buffers etc., and remove default JSON.stringify()
+// called on the data-source send.
+//
+//
+// The idea would be that by returning a special type of `Response`, we can also build some
+// client-side hooks such as "onEvent()" where you can listen to e.g. global onError and display
+// an appropriate error state
+export const res = {
+  json(payload: any) {
+    const res = new ServerResponse()
+    res.payload = payload
+    return res
+  },
+}
+
+export class ServerResponse {
+  actions: ActionEventDataState[] = []
+  payload: any
+
+  action(action: ActionEventDataState) {
+    this.actions.push(action)
+    return this
+  }
+}

--- a/packages/react/src/response.ts
+++ b/packages/react/src/response.ts
@@ -1,6 +1,6 @@
 import { ActionEventDataState, JSONValue } from './template'
 
-export const res = (payload: JSONValue): ServerResponseDataState => {
+export function createResponse(payload: JSONValue): ServerResponseDataState {
   return {
     $: 'response',
     payload,

--- a/packages/react/src/response.ts
+++ b/packages/react/src/response.ts
@@ -1,45 +1,38 @@
 import { ActionEventDataState, JSONValue } from './template'
 
-// tbd
-// what kind of API do we want?
-// e.g. `res.json().action([])`
-// or
-// `return makeActionResponse()
-// the implementation of this file will have to change based on the decision
-// benefit of `json()` is we can support array buffers etc., and remove default JSON.stringify()
-// called on the data-source send.
-//
-//
-// The idea would be that by returning a special type of `Response`, we can also build some
-// client-side hooks such as "onEvent()" where you can listen to e.g. global onError and display
-// an appropriate error state
-export const res = {
-  json(payload: JSONValue) {
-    const res = new ServerResponse()
-    res.payload = payload
-    return res
-  },
+export const res = (payload: JSONValue): ServerResponseDataState => {
+  return {
+    $: 'response',
+    payload,
+    // what are default values in `fetch`?
+    statusCode: 200,
+    ok: true,
+    actions: [],
+    action(action) {
+      this.actions.push(action)
+      return this
+    },
+    status(code: number) {
+      this.statusCode = code
+      this.ok = code >= 200 && code < 300
+      return this
+    },
+  }
 }
 
-export class ServerResponse {
-  actions: ActionEventDataState[] = []
-  payload: any
+export type ResponseDataState = {
+  $: 'response'
+  payload: JSONValue
+  statusCode: number
+  ok: boolean
+  actions: ActionEventDataState[]
+}
 
-  // what are default values in `fetch`?
-  statusCode: number = 200
-  ok: boolean = true
+export type ServerResponseDataState = ResponseDataState & {
+  action(action: ActionEventDataState): ServerResponseDataState
+  status(code: number): ServerResponseDataState
+}
 
-  action(action: any) {
-    this.actions.push({
-      $: 'event',
-      action,
-    })
-    return this
-  }
-
-  status(code: number) {
-    this.statusCode = code
-    this.ok = code >= 200 && code < 300
-    return this
-  }
+export function isResponseDataState(obj: any): obj is ResponseDataState {
+  return obj && typeof obj === 'object' && '$' in obj && obj.$ === 'response'
 }

--- a/packages/react/src/response.ts
+++ b/packages/react/src/response.ts
@@ -1,4 +1,4 @@
-import { ActionEventDataState, JSONValue } from './template'
+import { ActionDataState, JSONValue } from './template'
 
 // tbd
 // what kind of API do we want?
@@ -22,15 +22,18 @@ export const res = {
 }
 
 export class ServerResponse {
-  actions: ActionEventDataState[] = []
+  actions: ActionDataState[] = []
   payload: any
 
   // what are default values in `fetch`?
   statusCode: number = 200
   ok: boolean = true
 
-  action(action: ActionEventDataState) {
-    this.actions.push(action)
+  action(action: any) {
+    this.actions.push({
+      $: 'action',
+      action,
+    })
     return this
   }
 

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -97,7 +97,7 @@ export function BaseTemplate({
   path?: Path
   components: ComponentRegistry
   dataState: DataState
-  onEvent?: (event: TemplateEvent) => Promise<ServerResponse>
+  onEvent?: (event: TemplateEvent) => any
   onAction?: (action: ActionDataState['action']) => void
 }) {
   function renderComponent(stateNode: ComponentDataState, path: Path) {

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -45,11 +45,6 @@ export type HandlerEventDataState = {
   async: boolean
   timeout?: number
 }
-export function isHandlerEvent(
-  event: TemplateEvent
-): event is TemplateEvent<HandlerEventDataState> {
-  return isEventDataState(event.dataState) && 'key' in event.dataState
-}
 export function isActionEvent(event: TemplateEvent): event is TemplateEvent<ActionEventDataState> {
   return isEventDataState(event.dataState) && 'action' in event.dataState
 }
@@ -73,7 +68,6 @@ export type TemplateEvent<T = EventDataState, K = any> = {
   dataState: T
   payload: K
 }
-export type ActionEvent<T = any, K = any> = TemplateEvent<ActionEventDataState<T>, K>
 
 export function isCompositeDataState(obj: any): obj is ComponentDataState | ReferencedDataState {
   return (
@@ -104,7 +98,9 @@ export function BaseTemplate({
   path?: Path
   components: ComponentRegistry
   dataState: DataState
-  onEvent?: (event: TemplateEvent) => Promise<ServerResponse | null>
+  onEvent?: (
+    event: TemplateEvent<ActionEventDataState> | TemplateEvent<HandlerEventDataState>
+  ) => Promise<ServerResponse | null>
 }) {
   function renderComponent(stateNode: ComponentDataState, path: Path) {
     const componentDefinition = components[stateNode.component]

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -27,7 +27,7 @@ export type ReferencedDataState = {
   ref: Path
 }
 type EventDataState = ActionEventDataState | HandlerEventDataState
-export type ActionEventDataState<T = any> = {
+export type ActionEventDataState<T = string | string[]> = {
   $: 'event'
   action?: T
 }

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -33,6 +33,15 @@ export type ReferencedDataState = {
   $: 'ref'
   ref: Path
 }
+export type ActionEventDataState<T = any> = {
+  $: 'event'
+  action: T
+}
+export type HandlerEventDataState = {
+  $: 'event'
+  key: string
+  timeout?: number
+}
 export type JSONValue =
   | { [key: string]: JSONValue; $?: never }
   | string
@@ -55,15 +64,6 @@ type Event<T = any, K = any> = {
 export type ActionEvent = Event<ActionEventDataState>
 export type HandlerEvent = Event<HandlerEventDataState>
 export type TemplateEvent = ActionEvent | HandlerEvent
-export type ActionEventDataState<T = any> = {
-  $: 'event'
-  action: T
-}
-export type HandlerEventDataState = {
-  $: 'event'
-  key: string
-  timeout?: number
-}
 
 export function isCompositeDataState(obj: any): obj is ComponentDataState | ReferencedDataState {
   return (

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -17,7 +17,9 @@ export type DataState =
   | ReferencedDataState
   | ActionEventDataState
   | HandlerEventDataState
+  | { [key: string]: DataState; $?: never }
   | DataState[]
+
 export type ComponentDataState = {
   $: 'component'
   key?: string

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -42,7 +42,6 @@ export type ActionDataState<T = any> = {
 export type EventDataState = {
   $: 'event'
   key: string
-  async: boolean
   timeout?: number
 }
 export type JSONValue =

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -42,6 +42,10 @@ export type HandlerEventDataState = {
   key: string
   timeout?: number
 }
+export function isActionEvent(event: TemplateEvent): event is ActionEvent {
+  return isEventDataState(event.dataState) && 'action' in event.dataState
+}
+
 export type JSONValue =
   | { [key: string]: JSONValue; $?: never }
   | string
@@ -84,9 +88,6 @@ export function isEventDataState(
   obj: DataState
 ): obj is ActionEventDataState | HandlerEventDataState {
   return obj !== null && typeof obj === 'object' && '$' in obj && obj.$ === 'event'
-}
-export function isActionEvent(event: TemplateEvent): event is ActionEvent {
-  return isEventDataState(event.dataState) && 'action' in event.dataState
 }
 
 export function BaseTemplate({

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -51,7 +51,7 @@ export type JSONValue =
   | undefined
   | JSONValue[]
 
-type Event<T = any, K = any> = {
+export type TemplateEvent<T = any, K = any> = {
   target: {
     key?: string
     component: string
@@ -61,9 +61,8 @@ type Event<T = any, K = any> = {
   dataState: T
   payload: K
 }
-export type ActionEvent = Event<ActionEventDataState>
-export type HandlerEvent = Event<HandlerEventDataState>
-export type TemplateEvent = ActionEvent | HandlerEvent
+export type ActionEvent = TemplateEvent<ActionEventDataState>
+export type HandlerEvent = TemplateEvent<HandlerEventDataState>
 
 export function isCompositeDataState(obj: any): obj is ComponentDataState | ReferencedDataState {
   return (
@@ -178,8 +177,7 @@ export function BaseTemplate({
           },
           dataState: propValue,
           payload,
-          // tbd: can we avoid this cast?
-        } as TemplateEvent)
+        })
       }
     }
     if (Array.isArray(propValue)) {

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { ServerResponse } from './response'
+
 /** Components */
 type ComponentIdentifier = string
 
@@ -102,7 +104,7 @@ export function BaseTemplate({
   path?: Path
   components: ComponentRegistry
   dataState: DataState
-  onEvent?: (event: TemplateEvent) => Promise<any>
+  onEvent?: (event: TemplateEvent) => Promise<ServerResponse | null>
 }) {
   function renderComponent(stateNode: ComponentDataState, path: Path) {
     const componentDefinition = components[stateNode.component]

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -33,7 +33,7 @@ export type ReferencedDataState = {
   ref: Path
 }
 type EventDataState = ActionEventDataState | HandlerEventDataState
-export type ActionEventDataState<T = string | string[]> = {
+export type ActionEventDataState<T = any> = {
   $: 'event'
   action?: T
 }

--- a/packages/ws-client/src/__tests__/data-source.test.ts
+++ b/packages/ws-client/src/__tests__/data-source.test.ts
@@ -1,4 +1,4 @@
-import { TemplateEvent } from '@final-ui/react'
+import { res, TemplateEvent } from '@final-ui/react'
 import WS from 'jest-websocket-mock'
 
 import { createWSDataSource, EventResponseWebsocketMessage } from '../data-source'
@@ -31,14 +31,21 @@ it('should resolve a promise once response comes in', async () => {
   const response: EventResponseWebsocketMessage = {
     $: 'evt-res',
     key: 'key',
-    ok: true,
-    val: 'response',
+    res: res({}),
   }
 
   const promise = dataSource.sendEvent(event)
   ws.send(response)
 
-  expect(await promise).toEqual('response')
+  expect(await promise).toMatchInlineSnapshot(`
+    Object {
+      "$": "response",
+      "actions": Array [],
+      "ok": true,
+      "payload": Object {},
+      "statusCode": 200,
+    }
+  `)
 })
 
 it('should timeout if response comes later than timeout specified', async () => {
@@ -61,8 +68,7 @@ it('should timeout if response comes later than timeout specified', async () => 
   const response: EventResponseWebsocketMessage = {
     $: 'evt-res',
     key: 'key',
-    ok: true,
-    val: 'response',
+    res: res({}),
   }
 
   const promise = dataSource.sendEvent(event)

--- a/packages/ws-client/src/data-source.ts
+++ b/packages/ws-client/src/data-source.ts
@@ -3,7 +3,6 @@ import {
   type DataSource,
   DataSourceActionEventHandler,
   DataState,
-  isActionEvent,
   isHandlerEvent,
   ServerResponse,
   Store,
@@ -174,13 +173,6 @@ export function createWSDataSource(wsUrl: string): WebSocketDataSource {
       return () => actionEventHandlers.delete(handler)
     },
     sendEvent: async (event) => {
-      if (isActionEvent(event)) {
-        actionEventHandlers.forEach((handler) => {
-          handler(event.dataState)
-        })
-        // optional - do not send action event to the server, because it could be local-only
-        return
-      }
       send({ $: 'evt', event })
       if (isHandlerEvent(event)) {
         return new Promise((resolve, reject) => {

--- a/packages/ws-client/src/data-source.ts
+++ b/packages/ws-client/src/data-source.ts
@@ -2,7 +2,6 @@ import {
   createWritableStream,
   type DataSource,
   DataState,
-  HandlerEventDataState,
   ServerResponse,
   Store,
   Stream,
@@ -22,7 +21,7 @@ export type UnsubscribeWebsocketMessage = {
 
 export type EventWebsocketMessage = {
   $: 'evt'
-  event: TemplateEvent<HandlerEventDataState>
+  event: TemplateEvent
 }
 
 export type UpdateWebsocketMessage = {

--- a/packages/ws-client/src/data-source.ts
+++ b/packages/ws-client/src/data-source.ts
@@ -3,6 +3,7 @@ import {
   type DataSource,
   DataSourceActionEventHandler,
   DataState,
+  isActionEvent,
   isHandlerEvent,
   ServerResponse,
   Store,
@@ -173,6 +174,13 @@ export function createWSDataSource(wsUrl: string): WebSocketDataSource {
       return () => actionEventHandlers.delete(handler)
     },
     sendEvent: async (event) => {
+      if (isActionEvent(event)) {
+        actionEventHandlers.forEach((handler) => {
+          handler(event.dataState)
+        })
+        // optional - do not send action event to the server, because it could be local-only
+        return
+      }
       send({ $: 'evt', event })
       if (isHandlerEvent(event)) {
         return new Promise((resolve, reject) => {

--- a/packages/ws-client/src/data-source.ts
+++ b/packages/ws-client/src/data-source.ts
@@ -3,7 +3,7 @@ import {
   type DataSource,
   DataState,
   HandlerEvent,
-  ServerResponse,
+  ServerResponseDataState,
   Store,
   Stream,
 } from '@final-ui/react'
@@ -33,7 +33,7 @@ export type UpdateWebsocketMessage = {
 export type EventResponseWebsocketMessage = {
   $: 'evt-res'
   key: string
-  res: ServerResponse
+  res: ServerResponseDataState
 }
 
 export type ClientWebsocketMessage =
@@ -141,7 +141,7 @@ export function createWSDataSource(wsUrl: string): WebSocketDataSource {
     }
   }
 
-  const promises = new Map<string, (value: ServerResponse) => void>()
+  const promises = new Map<string, (value: ServerResponseDataState) => void>()
 
   return {
     get: (key: string) => {

--- a/packages/ws-client/src/data-source.ts
+++ b/packages/ws-client/src/data-source.ts
@@ -2,10 +2,10 @@ import {
   createWritableStream,
   type DataSource,
   DataState,
+  HandlerEvent,
   ServerResponse,
   Store,
   Stream,
-  type TemplateEvent,
 } from '@final-ui/react'
 import ReconnectingWebSocket from 'reconnecting-websocket'
 
@@ -21,7 +21,7 @@ export type UnsubscribeWebsocketMessage = {
 
 export type EventWebsocketMessage = {
   $: 'evt'
-  event: TemplateEvent
+  event: HandlerEvent
 }
 
 export type UpdateWebsocketMessage = {

--- a/packages/ws-client/src/data-source.ts
+++ b/packages/ws-client/src/data-source.ts
@@ -3,7 +3,6 @@ import {
   type DataSource,
   DataSourceActionEventHandler,
   DataState,
-  isActionEvent,
   isHandlerEvent,
   ServerResponse,
   Store,
@@ -174,14 +173,6 @@ export function createWSDataSource(wsUrl: string): WebSocketDataSource {
       return () => actionEventHandlers.delete(handler)
     },
     sendEvent: async (event) => {
-      if (isActionEvent(event)) {
-        actionEventHandlers.forEach((handler) => handler(event.dataState))
-        // should we change it so that we never send ActionEvents to the server?
-        // we would remove "wsDataSource.onActionEvent()" and require all users to use functions as props
-        // that would be the cleanest and would save bandwidth. but it's not going to work for EG as that server
-        // is just too big for that change
-        // return
-      }
       send({ $: 'evt', event })
       if (isHandlerEvent(event)) {
         return new Promise((resolve, reject) => {

--- a/packages/ws-server/src/data-source.ts
+++ b/packages/ws-server/src/data-source.ts
@@ -1,12 +1,11 @@
 import {
-  ActionEvent,
   extractRefKey,
   getAllEventHandlers,
-  isHandlerEvent,
   res,
   ServerDataState,
   ServerHandlerFunction,
   ServerResponse,
+  TemplateEvent,
 } from '@final-ui/react'
 import type {
   ClientWebsocketMessage,
@@ -17,7 +16,7 @@ import type {
 } from '@final-ui/ws-client'
 
 type ActionEventHandler = (
-  event: ActionEvent,
+  event: TemplateEvent<ActionEventHandler>,
   eventOpts: {
     time: number
     clientId: string
@@ -81,11 +80,6 @@ export function createWSServerDataSource() {
   }
 
   async function handleMessage(clientId: string, message: EventWebsocketMessage) {
-    if (!isHandlerEvent(message.event)) {
-      eventSubscribers.forEach((handler) => handler(message.event, { time: Date.now(), clientId }))
-      return
-    }
-
     const {
       dataState,
       target: { path },

--- a/packages/ws-server/src/data-source.ts
+++ b/packages/ws-server/src/data-source.ts
@@ -1,9 +1,9 @@
 import {
+  createResponse,
   extractRefKey,
   getAllEventHandlers,
   HandlerEvent,
   isResponseDataState,
-  res,
   ServerDataState,
   ServerHandlerFunction,
 } from '@final-ui/react'
@@ -97,7 +97,7 @@ export function createWSServerDataSource() {
       }
       let response = await handleEvent(message.event)
       if (!isResponseDataState(response)) {
-        response = res(response ?? null)
+        response = createResponse(response ?? null)
       }
       clientSenders.get(clientId)?.({
         $: 'evt-res',
@@ -108,7 +108,7 @@ export function createWSServerDataSource() {
       clientSenders.get(clientId)?.({
         $: 'evt-res',
         key: dataState.key,
-        res: res(error).status(500),
+        res: createResponse(error).status(500),
       })
       return
     }

--- a/packages/ws-server/src/data-source.ts
+++ b/packages/ws-server/src/data-source.ts
@@ -1,9 +1,10 @@
 import {
   extractRefKey,
   getAllEventHandlers,
+  isResponseDataState,
   res,
   ServerDataState,
-  ServerResponse,
+  ServerHandlerFunction,
 } from '@final-ui/react'
 import type {
   ClientWebsocketMessage,
@@ -83,8 +84,8 @@ export function createWSServerDataSource() {
         return
       }
       let response = await handleEvent(message.event)
-      if (!(response instanceof ServerResponse)) {
-        response = res.json(response)
+      if (!isResponseDataState(response)) {
+        response = res(response)
       }
       clientSenders.get(clientId)?.({
         $: 'evt-res',
@@ -95,7 +96,7 @@ export function createWSServerDataSource() {
       clientSenders.get(clientId)?.({
         $: 'evt-res',
         key: dataState.key,
-        res: res.json(error).status(500),
+        res: res(error).status(500),
       })
       return
     }

--- a/packages/ws-server/src/data-source.ts
+++ b/packages/ws-server/src/data-source.ts
@@ -85,7 +85,7 @@ export function createWSServerDataSource() {
       }
       let response = await handleEvent(message.event)
       if (!isResponseDataState(response)) {
-        response = res(response)
+        response = res(response ?? null)
       }
       clientSenders.get(clientId)?.({
         $: 'evt-res',

--- a/packages/ws-server/src/data-source.ts
+++ b/packages/ws-server/src/data-source.ts
@@ -3,7 +3,6 @@ import {
   getAllEventHandlers,
   res,
   ServerDataState,
-  ServerHandlerFunction,
   ServerResponse,
 } from '@final-ui/react'
 import type {
@@ -87,25 +86,18 @@ export function createWSServerDataSource() {
       if (!(response instanceof ServerResponse)) {
         response = res.json(response)
       }
-      if (dataState.async) {
-        clientSenders.get(clientId)?.({
-          $: 'evt-res',
-          key: dataState.key,
-          res: response,
-        })
-      }
+      clientSenders.get(clientId)?.({
+        $: 'evt-res',
+        key: dataState.key,
+        res: response,
+      })
     } catch (error: any) {
-      if (dataState.async) {
-        clientSenders.get(clientId)?.({
-          $: 'evt-res',
-          key: dataState.key,
-          res: res.json(error).status(500),
-        })
-        return
-      }
-      console.warn(
-        `Unhandled exception in event handler: ${message.event}. Error: ${JSON.stringify(error)}`
-      )
+      clientSenders.get(clientId)?.({
+        $: 'evt-res',
+        key: dataState.key,
+        res: res.json(error).status(500),
+      })
+      return
     }
   }
 

--- a/packages/ws-server/src/data-source.ts
+++ b/packages/ws-server/src/data-source.ts
@@ -5,7 +5,6 @@ import {
   ServerDataState,
   ServerHandlerFunction,
   ServerResponse,
-  TemplateEvent,
 } from '@final-ui/react'
 import type {
   ClientWebsocketMessage,
@@ -15,19 +14,10 @@ import type {
   UnsubscribeWebsocketMessage,
 } from '@final-ui/ws-client'
 
-type ActionEventHandler = (
-  event: TemplateEvent<ActionEventHandler>,
-  eventOpts: {
-    time: number
-    clientId: string
-  }
-) => void
-
 export function createWSServerDataSource() {
   const values = new Map<string, ServerDataState>()
 
   const clientSubscribers = new Map<string, Map<string, () => void>>()
-  const eventSubscribers = new Set<ActionEventHandler>()
   const subscribers = new Map<string, Set<(value: ServerDataState) => void>>()
 
   let clientIdIndex = 0
@@ -154,11 +144,6 @@ export function createWSServerDataSource() {
     update('', value)
   }
 
-  function onActionEvent(handler: ActionEventHandler) {
-    eventSubscribers.add(handler)
-    return () => eventSubscribers.delete(handler)
-  }
-
   function get(key: string) {
     return values.get(key)
   }
@@ -176,5 +161,5 @@ export function createWSServerDataSource() {
     return () => handlers.delete(handler)
   }
 
-  return { update, onActionEvent, subscribe, get, updateRoot, handleWSConnection }
+  return { update, subscribe, get, updateRoot, handleWSConnection }
 }


### PR DESCRIPTION
This PR adds ability for the data source to have impact on client-side behavior after responding to the request. It misses some tests and fine tuning, but I wanted to make sure we have directional agreement before committing more time to it. After initial approval, I will go ahead and complete missing tests.

On a high-level, from your event handler, you can return either plain object or an instance of Response:
```ts
{
  $: 'component',
  component: 'RiseForm',
  props: {
    onSubmit: handler((values) => {
      // handle on press, then
      return res.json()
        // send action
        .action(['navigate', 'goBack'])
        // or more
        .action(['some-other-action'])
    })
  }
}
```

Above example will instruct client to perform "goBack" navigation which is specific to Rise mobile application after 
succesfully handling action on the server. We should document them at some point, most likely in a follow-up PR, as we currently have just two.

> [!NOTE]
> In the future, we can hide `res.json().action(['navigate', 'goBack'])` behind something nicer.

## Other notable changes

- Remove non-async events
- Rename ActionEvent to Action
- Do not send ActionEvents to the server at all
- Updated JSONValue / DataState types. JSONValue is now included in DataState, not the other way around. That way, JSONValue cna be used as a type in places that expect actual JSON values.