### PR TITLE
feat: add utility assertion for uniform arrays

### DIFF
--- a/packages/react/src/__tests__/utils.test.ts
+++ b/packages/react/src/__tests__/utils.test.ts
@@ -1,0 +1,16 @@
+import { assertEvery } from '../utils'
+
+it('should return true if items are of the same type', () => {
+  expect(assertEvery([], (item) => typeof item === 'object')).toBe(true)
+  expect(assertEvery([1, 2, 3], (item: number) => typeof item === 'number')).toBe(true)
+  expect(assertEvery([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'event')).toBe(true)
+})
+
+it('should throw if items are different', () => {
+  expect(() =>
+    assertEvery([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'event')
+  ).toThrowError()
+  expect(() =>
+    assertEvery([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'action')
+  ).toThrowError()
+})

--- a/packages/react/src/__tests__/utils.test.ts
+++ b/packages/react/src/__tests__/utils.test.ts
@@ -1,17 +1,17 @@
-import { assertEvery } from '../utils'
+import { assertAll } from '../utils'
 
 it('should return true if items are of the same type', () => {
-  expect(assertEvery([], (item) => typeof item === 'object')).toBe(true)
-  expect(assertEvery([1, 2, 3], (item: number) => typeof item === 'number')).toBe(true)
-  expect(assertEvery([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'event')).toBe(true)
-  expect(assertEvery([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'action')).toBe(true)
+  expect(assertAll([], (item) => typeof item === 'object')).toBe(true)
+  expect(assertAll([1, 2, 3], (item: number) => typeof item === 'number')).toBe(true)
+  expect(assertAll([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'event')).toBe(true)
+  expect(assertAll([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'action')).toBe(false)
 })
 
 it('should throw if items are different', () => {
   expect(() =>
-    assertEvery([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'event')
+    assertAll([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'event')
   ).toThrowError()
   expect(() =>
-    assertEvery([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'action')
+    assertAll([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'action')
   ).toThrowError()
 })

--- a/packages/react/src/__tests__/utils.test.ts
+++ b/packages/react/src/__tests__/utils.test.ts
@@ -1,17 +1,27 @@
-import { assertAll } from '../utils'
+import { assertEveryOrNone } from '../utils'
 
 it('should return true if items are of the same type', () => {
-  expect(assertAll([], (item) => typeof item === 'object')).toBe(true)
-  expect(assertAll([1, 2, 3], (item: number) => typeof item === 'number')).toBe(true)
-  expect(assertAll([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'event')).toBe(true)
-  expect(assertAll([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'action')).toBe(false)
+  expect(assertEveryOrNone([], (item) => typeof item === 'object')).toBe(true)
+  expect(assertEveryOrNone([1, 2, 3], (item: number) => typeof item === 'number')).toBe(true)
+  expect(assertEveryOrNone([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'event')).toBe(
+    true
+  )
+  expect(assertEveryOrNone([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'action')).toBe(
+    false
+  )
 })
 
 it('should throw if items are different', () => {
   expect(() =>
-    assertAll([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'event')
+    assertEveryOrNone(
+      [{ $: 'event' }, { $: 'action' }, { $: 'event' }],
+      (item) => item.$ === 'event'
+    )
   ).toThrowError()
   expect(() =>
-    assertAll([{ $: 'event' }, { $: 'action' }, { $: 'event' }], (item) => item.$ === 'action')
+    assertEveryOrNone(
+      [{ $: 'event' }, { $: 'action' }, { $: 'event' }],
+      (item) => item.$ === 'action'
+    )
   ).toThrowError()
 })

--- a/packages/react/src/__tests__/utils.test.ts
+++ b/packages/react/src/__tests__/utils.test.ts
@@ -4,6 +4,7 @@ it('should return true if items are of the same type', () => {
   expect(assertEvery([], (item) => typeof item === 'object')).toBe(true)
   expect(assertEvery([1, 2, 3], (item: number) => typeof item === 'number')).toBe(true)
   expect(assertEvery([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'event')).toBe(true)
+  expect(assertEvery([{ $: 'event' }, { $: 'event' }], (item) => item.$ === 'action')).toBe(true)
 })
 
 it('should throw if items are different', () => {

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -189,6 +189,9 @@ export function BaseTemplate({
       }
     }
     if (Array.isArray(propValue)) {
+      if (propValue.length === 0) {
+        return
+      }
       if (assertEvery(propValue, isActionEventDataState)) {
         return async (payload: any) => {
           propValue.map((dataState) =>

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { assertEvery } from './utils'
+import { assertAll } from './utils'
 
 /** Components */
 type ComponentIdentifier = string
@@ -189,7 +189,7 @@ export function BaseTemplate({
       }
     }
     if (Array.isArray(propValue)) {
-      if (assertEvery(propValue, isActionEventDataState)) {
+      if (assertAll(propValue, isActionEventDataState)) {
         return async (payload: any) => {
           propValue.map((dataState) =>
             onTemplateEvent?.({

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { assertAll } from './utils'
+import { assertEveryOrNone } from './utils'
 
 /** Components */
 type ComponentIdentifier = string
@@ -189,7 +189,7 @@ export function BaseTemplate({
       }
     }
     if (Array.isArray(propValue)) {
-      if (assertAll(propValue, isActionEventDataState)) {
+      if (assertEveryOrNone(propValue, isActionEventDataState)) {
         return async (payload: any) => {
           propValue.map((dataState) =>
             onTemplateEvent?.({

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -189,9 +189,6 @@ export function BaseTemplate({
       }
     }
     if (Array.isArray(propValue)) {
-      if (propValue.length === 0) {
-        return
-      }
       if (assertEvery(propValue, isActionEventDataState)) {
         return async (payload: any) => {
           propValue.map((dataState) =>

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { assertEvery } from './utils'
+
 /** Components */
 type ComponentIdentifier = string
 
@@ -187,7 +189,7 @@ export function BaseTemplate({
       }
     }
     if (Array.isArray(propValue)) {
-      if (propValue.every(isActionEventDataState)) {
+      if (assertEvery(propValue, isActionEventDataState)) {
         return async (payload: any) => {
           propValue.map((dataState) =>
             onTemplateEvent?.({

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -189,9 +189,6 @@ export function BaseTemplate({
       }
     }
     if (Array.isArray(propValue)) {
-      if (propValue.length === 0) {
-        return
-      }
       if (assertEveryOrNone(propValue, isActionEventDataState)) {
         return async (payload: any) => {
           propValue.map((dataState) =>

--- a/packages/react/src/template.tsx
+++ b/packages/react/src/template.tsx
@@ -189,6 +189,9 @@ export function BaseTemplate({
       }
     }
     if (Array.isArray(propValue)) {
+      if (propValue.length === 0) {
+        return
+      }
       if (assertEveryOrNone(propValue, isActionEventDataState)) {
         return async (payload: any) => {
           propValue.map((dataState) =>

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,6 +1,7 @@
 export function assertEvery<T>(arr: T[], fn: (item: T) => boolean): boolean {
+  const firstItemResult: boolean = fn(arr[0] as T)
   for (const item of arr) {
-    if (!fn(item)) {
+    if (firstItemResult !== fn(item)) {
       throw new Error('All items in an array must be of the same type.')
     }
   }

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,9 +1,13 @@
-export function assertEvery<T>(arr: T[], fn: (item: T) => boolean): boolean {
+export function assertAll<T>(arr: T[], fn: (item: T) => boolean): boolean {
+  if (arr.length === 0) {
+    // as per Array.prototype.every
+    return true
+  }
   const firstItemResult: boolean = fn(arr[0] as T)
   for (const item of arr) {
     if (firstItemResult !== fn(item)) {
       throw new Error('All items in an array must be of the same type.')
     }
   }
-  return true
+  return firstItemResult
 }

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,4 +1,4 @@
-export function assertAll<T>(arr: T[], fn: (item: T) => boolean): boolean {
+export function assertEveryOrNone<T>(arr: T[], fn: (item: T) => boolean): boolean {
   if (arr.length === 0) {
     // as per Array.prototype.every
     return true

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,0 +1,8 @@
+export function assertEvery<T>(arr: T[], fn: (item: T) => boolean): boolean {
+  for (const item of arr) {
+    if (!fn(item)) {
+      throw new Error('All items in an array must be of the same type.')
+    }
+  }
+  return true
+}


### PR DESCRIPTION
Alternative to Array.prototype.every that throws if items are not all of the same type. That way, we can safely check for an array of "actions". Otherwise, current code would lead to [action(), "whatever"] to pass type checking, but lead to unexpected behavior during runtime.

After this PR, it will throw.